### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump version from 0.7.0 to 0.7.1
- Includes fork error log fixes merged in PR #12

## Changes
- `package.json`: version 0.7.0 → 0.7.1

## Test plan
- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [ ] Gemini review approved