### PR TITLE
fix: bind Feishu card model to the current prompt round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ openmemory.md
 .claude
 _Organized
 /logs/
+/docs/CLAUDE.md
+/output/1.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-feishu",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-feishu",
-      "version": "1.7.8",
+      "version": "1.7.9",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.56.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "1.7.8",
+  "version": "1.7.9",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",

--- a/src/feishu/streaming-card.ts
+++ b/src/feishu/streaming-card.ts
@@ -240,13 +240,19 @@ export class StreamingCard {
     if (!this.cardId || this.debugPanelAdded) return
 
     const toolCount = this.toolStates.size
-    const completedCount = [...this.toolStates.values()].filter((tool) => tool.state === "completed").length
-    const runningCount = [...this.toolStates.values()].filter((tool) => tool.state === "running").length
-    const errorCount = [...this.toolStates.values()].filter((tool) => tool.state === "error").length
-    const toolSummary = [...this.toolStates.values()].map((tool) => {
+    let completedCount = 0
+    let runningCount = 0
+    let errorCount = 0
+    const toolSummaryParts: string[] = []
+    // 单次遍历同时生成计数和摘要，避免对同一份工具状态做多次扫描。
+    for (const tool of this.toolStates.values()) {
       const icon = tool.state === "completed" ? "✅" : tool.state === "error" ? "❌" : "🔄"
-      return `${icon} ${tool.tool}`
-    }).join(" · ")
+      toolSummaryParts.push(`${icon} ${tool.tool}`)
+      if (tool.state === "completed") completedCount += 1
+      else if (tool.state === "running") runningCount += 1
+      else if (tool.state === "error") errorCount += 1
+    }
+    const toolSummary = toolSummaryParts.join(" · ")
 
     // 折叠标题直接保留完整模型名；拿不到实际模型时就完全不展示。
     const summaryParts = [this.meta?.model, `${toolCount} tools`].filter(Boolean)

--- a/src/feishu/streaming-card.ts
+++ b/src/feishu/streaming-card.ts
@@ -23,6 +23,7 @@ interface ToolState {
 export interface StreamingCardMeta {
   sessionId?: string
   directory?: string
+  /** 只展示最终确认过的实际模型；流式阶段保持为空。 */
   model?: string
 }
 
@@ -43,6 +44,8 @@ export class StreamingCard {
   private closed = false
   /** tools 元素是否已经动态插入过。 */
   private toolsElementAdded = false
+  /** 调试面板只应在收尾时追加一次。 */
+  private debugPanelAdded = false
 
   constructor(
     private readonly cardkit: CardKitClient,
@@ -56,9 +59,6 @@ export class StreamingCard {
    * 创建卡片实体并发到飞书聊天，返回对应的消息 ID。
    */
   async start(): Promise<string> {
-    // 底部元信息仅用于辅助定位上下文，不影响主要展示内容。
-    const footer = [this.meta?.sessionId, this.meta?.directory, this.meta?.model].filter(Boolean).join(" | ")
-
     const schema: CardKitSchema = {
       data: {
         schema: "2.0",
@@ -70,7 +70,6 @@ export class StreamingCard {
         body: {
           elements: [
             { tag: "markdown", element_id: "content", content: "正在思考..." },
-            ...(footer ? [{ tag: "div", text: { tag: "plain_text", content: footer } }] : []),
           ],
         },
       },
@@ -135,7 +134,25 @@ export class StreamingCard {
     // 先等之前的更新队列跑完，再写最终内容，避免顺序错乱。
     await this.drain()
     await this.doUpdateContent()
+    // 元信息不再抢正文位置；收尾时再附一个默认折叠的调试面板。
+    try {
+      await this.appendDebugPanel()
+    } catch (err) {
+      this.log("error", "追加 StreamingCard 调试面板失败", {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
     await this.cardkit.closeStreaming(this.cardId, ++this.seq)
+  }
+
+  /**
+   * 在收尾前写入本次 assistant 实际执行模型。
+   *
+   * 这里故意不在流式阶段展示模型，避免把配置值或尚未确认的临时值暴露给用户。
+   */
+  setResolvedModel(model: string | undefined): void {
+    if (!this.meta) return
+    this.meta.model = model
   }
 
   /**
@@ -210,5 +227,59 @@ export class StreamingCard {
         ++this.seq,
       )
     }
+  }
+
+  /**
+   * 在卡片底部追加一个默认折叠的调试面板。
+   *
+   * 这里刻意只在 close 时写入最终值：
+   * - 不让 session/path/model 抢占正文空间
+   * - 工具摘要只在收尾时给最终稳定值，避免流式阶段频繁跳动
+   */
+  private async appendDebugPanel(): Promise<void> {
+    if (!this.cardId || this.debugPanelAdded) return
+
+    const toolCount = this.toolStates.size
+    const completedCount = [...this.toolStates.values()].filter((tool) => tool.state === "completed").length
+    const runningCount = [...this.toolStates.values()].filter((tool) => tool.state === "running").length
+    const errorCount = [...this.toolStates.values()].filter((tool) => tool.state === "error").length
+    const toolSummary = [...this.toolStates.values()].map((tool) => {
+      const icon = tool.state === "completed" ? "✅" : tool.state === "error" ? "❌" : "🔄"
+      return `${icon} ${tool.tool}`
+    }).join(" · ")
+
+    // 折叠标题直接保留完整模型名；拿不到实际模型时就完全不展示。
+    const summaryParts = [this.meta?.model, `${toolCount} tools`].filter(Boolean)
+    const summaryTitle =
+      summaryParts.length > 0 ? `调试信息 · ${summaryParts.join(" · ")}` : "调试信息"
+
+    const detailLines: string[] = []
+    // 完整路径 / sessionId 只放在折叠详情里，默认不抢正文注意力，但需要时仍能展开查看。
+    if (this.meta?.directory) detailLines.push(`- 工作区：\`${this.meta.directory}\``)
+    if (this.meta?.model) detailLines.push(`- 模型：\`${this.meta.model}\``)
+    if (this.meta?.sessionId) detailLines.push(`- 会话：\`${this.meta.sessionId}\``)
+    detailLines.push(`- 工具数：\`${toolCount}\`（完成 ${completedCount} / 运行中 ${runningCount} / 失败 ${errorCount}）`)
+    if (toolSummary) detailLines.push(`- 工具摘要：${toolSummary}`)
+    // 总耗时目前只是本地 wall-clock 估算，不代表 SDK/模型真实执行时长，因此不对用户展示。
+
+    await this.cardkit.addElement(
+      this.cardId,
+      [{
+        tag: "collapsible_panel",
+        expanded: false,
+        header: {
+          title: {
+            tag: "plain_text",
+            content: summaryTitle,
+          },
+        },
+        elements: [{
+          tag: "markdown",
+          content: detailLines.join("\n"),
+        }],
+      }],
+      ++this.seq,
+    )
+    this.debugPanelAdded = true
   }
 }

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -645,7 +645,8 @@ function extractAssistantModelForRequests(
 
     const providerID = typeof assistant.providerID === "string" ? assistant.providerID.trim() : ""
     const modelID = typeof assistant.modelID === "string" ? assistant.modelID.trim() : ""
-    if (!providerID || !modelID) return undefined
+    // 同一轮里可能先出现一个尚未补全模型字段的 assistant 记录，此时继续向前找稳定记录。
+    if (!providerID || !modelID) continue
 
     return `${providerID}/${modelID}`
   }

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -11,6 +11,7 @@
  */
 import type { FeishuMessageContext, ResolvedConfig, LogFn } from "../types.js"
 import type { OpencodeClient } from "@opencode-ai/sdk"
+import { randomUUID } from "node:crypto"
 import * as sender from "../feishu/sender.js"
 import {
   registerPending, unregisterPending,
@@ -78,23 +79,35 @@ function traceLangfuseUser(
 }
 
 /**
- * 读取当前 OpenCode 配置中的模型名。
+ * 为当前 prompt 生成稳定的 user messageID。
  *
- * 这是 UI 增强信息，不是主链路必需，因此读取失败只返回 `undefined`，
- * 同时留下 error 日志供排查。
+ * 后续回读实际模型时，只认和这个 ID 关联出来的 assistant message，
+ * 避免把上一轮对话的模型误展示到当前卡片。
  */
-async function fetchModel(
+function createPromptMessageId(): string {
+  return randomUUID()
+}
+
+/**
+ * 从当前请求关联的 assistant message 读取实际执行模型。
+ *
+ * 这里优先信任运行结果本身的 `providerID/modelID`，
+ * 而不是配置里的默认模型，避免自动恢复或局部 override 后显示错误。
+ */
+async function fetchActualModel(
   client: OpencodeClient,
+  sessionId: string,
+  requestMessageIds: readonly string[],
   log: LogFn,
   query?: { directory?: string },
 ): Promise<string | undefined> {
   try {
-    const cfg = await client.config.get({ query })
-    const m = cfg?.data?.model
-    return typeof m === "string" ? m : undefined
+    const { data: messages } = await client.session.messages({ path: { id: sessionId }, query })
+    return extractAssistantModelForRequests(messages ?? [], requestMessageIds)
   } catch (err) {
-    // 模型信息只影响卡片辅助展示，但异常仍要留下 error 日志。
-    log("error", "读取当前模型配置失败", {
+    // 模型信息只影响卡片辅助展示；读取失败时回退为不展示模型。
+    log("error", "读取本次 assistant 实际模型失败", {
+      sessionId,
       error: err instanceof Error ? err.message : String(err),
     })
     return undefined
@@ -122,8 +135,11 @@ async function finalizeReply(
   placeholderId: string,
   text: string,
   log: LogFn,
+  actualModel?: string,
 ): Promise<void> {
   if (streamingCard) {
+    // 只在收尾时写入最终确认过的实际模型，流式阶段保持不展示。
+    streamingCard.setResolvedModel(actualModel)
     await streamingCard.close(text)
   } else {
     await replyOrUpdate(feishuClient, chatId, placeholderId, text, log)
@@ -191,6 +207,8 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
   const thinkingDelay = config.thinkingDelay
   const pollInterval = config.pollInterval
   const stablePolls = config.stablePolls
+  // 当前用户可见这一轮可能会产生多次 prompt（原始尝试 + 自动恢复），统一记录它们的 messageID。
+  const requestMessageIds: string[] = []
 
   let placeholderId = ""
   // `done` 用于避免 thinking timer 在主流程已结束后再异步发出占位消息。
@@ -204,7 +222,6 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       streamingCard = new StreamingCard(deps.cardkit, feishuClient, chatId, log, {
         sessionId: session.id,
         directory,
-        model: await fetchModel(client, log, query),
       })
       placeholderId = await streamingCard.start()
     } catch (err) {
@@ -297,11 +314,13 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
   try {
     // 清除前次遗留的 session error 缓存，避免 pollForResponse 误检测旧错误。
     clearSessionError(session.id)
+    const requestMessageId = createPromptMessageId()
+    requestMessageIds.push(requestMessageId)
 
     await client.session.promptAsync({
       path: { id: session.id },
       query,
-      body: baseBody,
+      body: { ...baseBody, messageID: requestMessageId },
     })
 
     const finalText = await pollForResponse(client, session.id, { timeout, pollInterval, stablePolls, query, signal })
@@ -315,7 +334,8 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     // prompt 成功：清空该 sessionKey 的自动恢复计数。
     clearRetryAttempts(sessionKey)
 
-    await finalizeReply(streamingCard, feishuClient, chatId, placeholderId, finalText || "⚠️ 响应超时", log)
+    const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+    await finalizeReply(streamingCard, feishuClient, chatId, placeholderId, finalText || "⚠️ 响应超时", log, actualModel)
   } catch (err) {
     // 提取会话错误信息（来自 SessionErrorDetected 或 SSE 缓存）
     const sessionError = extractSessionError(err, session.id)
@@ -335,14 +355,18 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     // 只有拿到了结构化 sessionError，才尝试做模型错误恢复。
     if (sessionError) {
       try {
+        const recoveryRequestMessageId = createPromptMessageId()
+        requestMessageIds.push(recoveryRequestMessageId)
         const recovery = await tryModelRecovery({
           sessionError, sessionId: session.id, sessionKey, client, directory,
+          requestMessageId: recoveryRequestMessageId,
           parts, timeout, pollInterval, stablePolls, query, signal, log,
           poll: pollForResponse,
         })
 
         if (recovery.recovered) {
-          await finalizeReply(streamingCard, feishuClient, chatId, placeholderId, recovery.text || "⚠️ 响应超时", log)
+          const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+          await finalizeReply(streamingCard, feishuClient, chatId, placeholderId, recovery.text || "⚠️ 响应超时", log, actualModel)
           return
         }
         displayError = recovery.sessionError
@@ -359,7 +383,8 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       error: thrownError,
       ...(displayError ? { sessionError: displayError.message } : {}),
     })
-    await finalizeReply(streamingCard, feishuClient, chatId, placeholderId, "❌ " + errorMessage, log)
+    const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+    await finalizeReply(streamingCard, feishuClient, chatId, placeholderId, "❌ " + errorMessage, log, actualModel)
   } finally {
     done = true
     // 无论成功失败，都要把延迟占位计时器、订阅和 pending 状态回收掉。
@@ -588,4 +613,42 @@ function extractLastAssistantText(
     .map((p) => p.text ?? "")
     .join("\n")
     .trim()
+}
+
+/**
+ * 从当前请求关联的 assistant message 提取真实执行模型。
+ *
+ * 这里只认 `parentID` 命中的 assistant message，
+ * 避免把历史轮次的模型串到当前卡片里。
+ */
+function extractAssistantModelForRequests(
+  messages: Array<{
+    info: {
+      role?: string
+      parentID?: unknown
+      providerID?: unknown
+      modelID?: unknown
+      [key: string]: unknown
+    }
+  }>,
+  requestMessageIds: readonly string[],
+): string | undefined {
+  if (requestMessageIds.length === 0) return undefined
+  const requestIdSet = new Set(requestMessageIds)
+
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const assistant = messages[index]?.info
+    if (assistant?.role !== "assistant") continue
+
+    const parentID = typeof assistant.parentID === "string" ? assistant.parentID.trim() : ""
+    if (!parentID || !requestIdSet.has(parentID)) continue
+
+    const providerID = typeof assistant.providerID === "string" ? assistant.providerID.trim() : ""
+    const modelID = typeof assistant.modelID === "string" ? assistant.modelID.trim() : ""
+    if (!providerID || !modelID) return undefined
+
+    return `${providerID}/${modelID}`
+  }
+
+  return undefined
 }

--- a/src/handler/error-recovery.ts
+++ b/src/handler/error-recovery.ts
@@ -102,6 +102,7 @@ export async function tryModelRecovery(params: {
   readonly sessionKey: string
   readonly client: OpencodeClient
   readonly directory?: string
+  readonly requestMessageId: string
   readonly parts: readonly PromptPart[]
   readonly timeout?: number
   readonly pollInterval: number
@@ -113,6 +114,7 @@ export async function tryModelRecovery(params: {
 }): Promise<RecoveryResult> {
   const {
     sessionError, sessionId, sessionKey, client, directory,
+    requestMessageId,
     parts, timeout, pollInterval, stablePolls, query, signal,
     log, poll,
   } = params
@@ -164,7 +166,8 @@ export async function tryModelRecovery(params: {
     await client.session.promptAsync({
       path: { id: sessionId },
       query,
-      body: { parts: [...parts], model: modelOverride },
+      // 恢复尝试也显式绑定一个 user messageID，便于上层只读取这次尝试的实际模型。
+      body: { parts: [...parts], model: modelOverride, messageID: requestMessageId },
     })
 
     const finalText = await poll(client, sessionId, {


### PR DESCRIPTION
## Summary
- bind Feishu card debug model metadata to the current prompt round instead of the session's last assistant message
- only resolve model metadata at close time so streaming cards do not expose speculative or stale model info
- keep recovery attempts bound to their own request message id for the same final-round lookup path

## Changes
- add per-prompt messageID generation in chat.ts and use it when sending the primary prompt
- scope actual-model lookup to assistant messages whose parentID matches the current round request ids
- pass a dedicated request message id through the model-recovery path

## Test Plan
- npm run typecheck
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Debug information now appears only after streaming finishes and is shown collapsed to avoid distracting from live responses.
  * Model information is deferred until the response is finalized, ensuring the final reply shows the actual model used across attempts.
  * Error-recovery flows now correctly attribute the executed model after retries, improving accuracy of final metadata.
* **Chores**
  * Package version updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->