### PR TITLE
feat(026): 兼容最新 OpenCode SDK — message.part.delta 事件处理 + SDK 升级

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-feishu",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-feishu",
-      "version": "1.7.10",
+      "version": "1.7.11",
       "license": "MIT",
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.56.1",
@@ -14,14 +14,14 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
-        "@opencode-ai/plugin": "^1.1.53",
+        "@opencode-ai/plugin": "^1.14.18",
         "@types/node": "^22.0.0",
         "bumpp": "^10.4.1",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=20.3.0"
       },
       "peerDependencies": {
         "@opencode-ai/plugin": ">=1.1.0",
@@ -524,15 +524,112 @@
         "ws": "^8.16.0"
       }
     },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.1.53",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.1.53.tgz",
-      "integrity": "sha512-9ye7Wz2kESgt02AUDaMea4hXxj6XhWwKAG8NwFhrw09Ux54bGaMJFt1eIS8QQGIMaD+Lp11X4QdyEg96etEBJw==",
+      "version": "1.14.18",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@opencode-ai/plugin/-/plugin-1.14.18.tgz",
+      "integrity": "sha512-oF1U7Aipz8A93WGllrwxYugopeL4ml/zd6ywoFIyuF2gbvEhOGFomAvqt1E5YjLN0wEL8nCPwFine3l7pqgNUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.1.53",
+        "@opencode-ai/sdk": "1.14.18",
+        "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.100",
+        "@opentui/solid": ">=0.1.100"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
       }
     },
     "node_modules/@opencode-ai/plugin/node_modules/zod": {
@@ -546,10 +643,14 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.1.53",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.1.53.tgz",
-      "integrity": "sha512-RUIVnPOP1CyyU32FrOOYuE7Ge51lOBuhaFp2NSX98ncApT7ffoNetmwzqrhOiJQgZB1KrbCHLYOCK6AZfacxag==",
-      "license": "MIT"
+      "version": "1.14.18",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@opencode-ai/sdk/-/sdk-1.14.18.tgz",
+      "integrity": "sha512-E0QiiB+9rv/TPH0a1GunKl6LnuXDRHDiJaIFHOPaBL364rQx+3ClHwHkz78/KBsjhjeLrC2CaLgK+CoxV/XUIQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -965,6 +1066,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1278,6 +1386,20 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1318,6 +1440,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -1343,6 +1476,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.48",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/effect/-/effect-4.0.0-beta.48.tgz",
+      "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.6.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^6.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^1.11.9",
+        "multipasta": "^0.2.7",
+        "toml": "^4.1.1",
+        "uuid": "^13.0.0",
+        "yaml": "^2.8.3"
       }
     },
     "node_modules/es-define-property": {
@@ -1397,6 +1549,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1449,6 +1602,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1466,6 +1642,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
@@ -1658,6 +1841,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -1684,6 +1883,13 @@
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1798,6 +2004,46 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.10",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/msgpackr/-/msgpackr-1.11.10.tgz",
+      "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1816,6 +2062,22 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/nypm": {
       "version": "0.6.5",
@@ -1888,6 +2150,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1915,6 +2186,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2015,6 +2287,23 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/qs": {
@@ -2123,6 +2412,27 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/side-channel": {
@@ -2277,6 +2587,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/toml": {
+      "version": "4.1.1",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/toml/-/toml-4.1.1.tgz",
+      "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -2353,6 +2673,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2373,6 +2694,35 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "13.0.0",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -2396,9 +2746,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -526,7 +526,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
       "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
       "cpu": [
         "arm64"
@@ -540,7 +540,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
       "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
       "cpu": [
         "x64"
@@ -554,7 +554,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
       "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
       "cpu": [
         "arm"
@@ -568,7 +568,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
       "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
       "cpu": [
         "arm64"
@@ -582,7 +582,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
       "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
       "cpu": [
         "x64"
@@ -596,7 +596,7 @@
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
       "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
       "cpu": [
         "x64"
@@ -610,7 +610,7 @@
     },
     "node_modules/@opencode-ai/plugin": {
       "version": "1.14.18",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@opencode-ai/plugin/-/plugin-1.14.18.tgz",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.18.tgz",
       "integrity": "sha512-oF1U7Aipz8A93WGllrwxYugopeL4ml/zd6ywoFIyuF2gbvEhOGFomAvqt1E5YjLN0wEL8nCPwFine3l7pqgNUA==",
       "dev": true,
       "license": "MIT",
@@ -644,7 +644,7 @@
     },
     "node_modules/@opencode-ai/sdk": {
       "version": "1.14.18",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@opencode-ai/sdk/-/sdk-1.14.18.tgz",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.18.tgz",
       "integrity": "sha512-E0QiiB+9rv/TPH0a1GunKl6LnuXDRHDiJaIFHOPaBL364rQx+3ClHwHkz78/KBsjhjeLrC2CaLgK+CoxV/XUIQ==",
       "license": "MIT",
       "peer": true,
@@ -1068,7 +1068,7 @@
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
@@ -1388,7 +1388,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
@@ -1442,7 +1442,7 @@
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/detect-libc/-/detect-libc-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
@@ -1480,7 +1480,7 @@
     },
     "node_modules/effect": {
       "version": "4.0.0-beta.48",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/effect/-/effect-4.0.0-beta.48.tgz",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.48.tgz",
       "integrity": "sha512-MMAM/ZabuNdNmgXiin+BAanQXK7qM8mlt7nfXDoJ/Gn9V8i89JlCq+2N0AiWmqFLXjGLA0u3FjiOjSOYQk5uMw==",
       "dev": true,
       "license": "MIT",
@@ -1604,7 +1604,7 @@
     },
     "node_modules/fast-check": {
       "version": "4.7.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/fast-check/-/fast-check-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
       "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
       "dev": true,
       "funding": [
@@ -1645,7 +1645,7 @@
     },
     "node_modules/find-my-way-ts": {
       "version": "0.1.6",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
       "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
       "dev": true,
       "license": "MIT"
@@ -1843,7 +1843,7 @@
     },
     "node_modules/ini": {
       "version": "6.0.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/ini/-/ini-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
       "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
       "dev": true,
       "license": "ISC",
@@ -1853,7 +1853,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
@@ -1886,7 +1886,7 @@
     },
     "node_modules/kubernetes-types": {
       "version": "1.30.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
       "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
       "dev": true,
       "license": "Apache-2.0"
@@ -2006,7 +2006,7 @@
     },
     "node_modules/msgpackr": {
       "version": "1.11.10",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/msgpackr/-/msgpackr-1.11.10.tgz",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.10.tgz",
       "integrity": "sha512-iCZNq+HszvF+fC3anCm4nBmWEnbeIAfpDs6IStAEKhQ2YSgkjzVG2FF9XJqwwQh5bH3N9OUTUt4QwVN6MLMLtA==",
       "dev": true,
       "license": "MIT",
@@ -2016,7 +2016,7 @@
     },
     "node_modules/msgpackr-extract": {
       "version": "3.0.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
       "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
       "dev": true,
       "hasInstallScript": true,
@@ -2039,7 +2039,7 @@
     },
     "node_modules/multipasta": {
       "version": "0.2.7",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/multipasta/-/multipasta-0.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
       "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "dev": true,
       "license": "MIT"
@@ -2065,7 +2065,7 @@
     },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
       "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
       "dev": true,
       "license": "MIT",
@@ -2152,7 +2152,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/path-key/-/path-key-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "license": "MIT",
       "engines": {
@@ -2291,7 +2291,7 @@
     },
     "node_modules/pure-rand": {
       "version": "8.4.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/pure-rand/-/pure-rand-8.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
       "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
       "dev": true,
       "funding": [
@@ -2416,7 +2416,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/shebang-command/-/shebang-command-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "license": "MIT",
       "dependencies": {
@@ -2428,7 +2428,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "license": "MIT",
       "engines": {
@@ -2589,7 +2589,7 @@
     },
     "node_modules/toml": {
       "version": "4.1.1",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/toml/-/toml-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.1.1.tgz",
       "integrity": "sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==",
       "dev": true,
       "license": "MIT",
@@ -2697,7 +2697,7 @@
     },
     "node_modules/uuid": {
       "version": "13.0.0",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/uuid/-/uuid-13.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
       "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
       "dev": true,
       "funding": [
@@ -2711,7 +2711,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/which/-/which-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "license": "ISC",
       "dependencies": {
@@ -2747,7 +2747,7 @@
     },
     "node_modules/yaml": {
       "version": "2.8.3",
-      "resolved": "https://artifactory.release.ctripcorp.com/artifactory/api/npm/trip-npm-prod/yaml/-/yaml-2.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",
@@ -40,7 +40,7 @@
     "@opencode-ai/sdk": ">=1.0.0"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "^1.1.53",
+    "@opencode-ai/plugin": "^1.14.18",
     "@types/node": "^22.0.0",
     "bumpp": "^10.4.1",
     "tsup": "^8.0.0",

--- a/src/handler/event.ts
+++ b/src/handler/event.ts
@@ -218,7 +218,7 @@ export async function handleEvent(
 ): Promise<void> {
   switch (event.type as string) {
     case "message.part.delta": {
-      const props = (event as { properties: Record<string, unknown> }).properties as {
+      const props = (event as any).properties as {
         sessionID?: string
         messageID?: string
         delta?: string
@@ -235,7 +235,7 @@ export async function handleEvent(
         const res = await sender.updateMessage(
           deltaPayload.feishuClient,
           deltaPayload.placeholderId,
-          deltaPayload.textBuffer.trim(),
+          deltaPayload.textBuffer || " ",
           deps.log,
         )
         if (!res.ok) {
@@ -256,7 +256,7 @@ export async function handleEvent(
       break
     }
     case "message.part.updated": {
-      const part = (event as { properties: { part?: { sessionID?: string; messageID?: unknown; type?: string; text?: string; [key: string]: unknown } } }).properties.part
+      const part = (event as any).properties?.part as { sessionID?: string; messageID?: unknown; type?: string; text?: string; [key: string]: unknown } | undefined
       if (!part?.sessionID) break
       const payload = pendingBySession.get(part.sessionID)
       if (!payload) break
@@ -344,7 +344,7 @@ async function handleMessagePartUpdated(
     const res = await sender.updateMessage(
       payload.feishuClient,
       payload.placeholderId,
-      payload.textBuffer.trim(),
+      payload.textBuffer || " ",
       log,
     )
     if (!res.ok) {

--- a/src/handler/event.ts
+++ b/src/handler/event.ts
@@ -216,9 +216,47 @@ export async function handleEvent(
   event: Event,
   deps: EventDeps,
 ): Promise<void> {
-  switch (event.type) {
+  switch (event.type as string) {
+    case "message.part.delta": {
+      const props = (event as { properties: Record<string, unknown> }).properties as {
+        sessionID?: string
+        messageID?: string
+        delta?: string
+      }
+      const { sessionID, messageID, delta } = props
+      if (!sessionID || !delta) break
+      const deltaPayload = pendingBySession.get(sessionID)
+      if (!deltaPayload) break
+      if (!matchOrLatchMessageId(deltaPayload, messageID)) return
+      deltaPayload.hasActivity = true
+      deltaPayload.textBuffer += delta
+
+      if (deltaPayload.mirrorTextToMessage && deltaPayload.placeholderId && deltaPayload.textBuffer) {
+        const res = await sender.updateMessage(
+          deltaPayload.feishuClient,
+          deltaPayload.placeholderId,
+          deltaPayload.textBuffer.trim(),
+          deps.log,
+        )
+        if (!res.ok) {
+          deps.log("error", "更新飞书占位消息失败（delta）", {
+            sessionId: sessionID,
+            placeholderId: deltaPayload.placeholderId,
+            error: res.error ?? "unknown",
+          })
+        }
+      }
+
+      emit(sessionID, {
+        type: "text-updated",
+        sessionId: sessionID,
+        delta,
+        fullText: deltaPayload.textBuffer,
+      }, deps.log)
+      break
+    }
     case "message.part.updated": {
-      const part = event.properties.part
+      const part = (event as { properties: { part?: { sessionID?: string; messageID?: unknown; type?: string; text?: string; [key: string]: unknown } } }).properties.part
       if (!part?.sessionID) break
       const payload = pendingBySession.get(part.sessionID)
       if (!payload) break
@@ -240,7 +278,7 @@ export async function handleEvent(
  * - 广播 action-bus 事件给其他消费者
  */
 async function handleMessagePartUpdated(
-  event: Event,
+  _event: Event,
   part: { sessionID?: string; messageID?: unknown; type?: string; text?: string; [key: string]: unknown },
   payload: PendingReplyPayload,
   log: LogFn,
@@ -292,17 +330,13 @@ async function handleMessagePartUpdated(
     return
   }
 
-  // delta 是增量文本，part.text 是全量文本
-  const delta = (event.properties as { delta?: string }).delta
-  if (delta) {
-    // 增量事件：直接把 delta 追加进已有 buffer。
-    payload.textBuffer += delta
-  } else {
-    const fullText = extractPartText(part)
-    if (fullText) {
-      // 快照事件：整段替换 buffer，避免重复拼接。
-      payload.textBuffer = fullText
-    }
+  // message.part.updated 只处理 text 类型的全量快照（delta 已由 message.part.delta 处理）
+  if (part.type !== "text") return
+
+  const fullText = extractPartText(part)
+  if (fullText) {
+    // 快照事件：整段替换 buffer，避免重复拼接。
+    payload.textBuffer = fullText
   }
 
   if (payload.mirrorTextToMessage && payload.placeholderId && payload.textBuffer) {
@@ -322,12 +356,12 @@ async function handleMessagePartUpdated(
     }
   }
 
-  // Emit text-updated action to action-bus
-  if (partSessionId) {
+  // Emit text-updated action to action-bus (snapshot only, no delta)
+  if (partSessionId && payload.textBuffer) {
     emit(partSessionId, {
       type: "text-updated",
       sessionId: partSessionId,
-      delta: delta ?? undefined,
+      delta: undefined,
       fullText: payload.textBuffer,
     }, log)
   }

--- a/src/handler/interactive.ts
+++ b/src/handler/interactive.ts
@@ -230,7 +230,7 @@ export function handlePermissionRequested(
     chatId,
     deps,
     card: buildPermissionCardDSL(request, chatId, chatType, sessionId),
-    missingClientMessage: "v2Client 未配置，跳过权限卡片发送",
+    missingClientMessage: "OpenCode client 未配置，跳过权限卡片发送",
     sendFailureMessage: "发送权限卡片失败",
   })
 }
@@ -253,7 +253,7 @@ export function handleQuestionRequested(
     chatId,
     deps,
     card: buildQuestionCardDSL(request, chatId, chatType, sessionId),
-    missingClientMessage: "v2Client 未配置，跳过问答卡片发送",
+    missingClientMessage: "OpenCode client 未配置，跳过问答卡片发送",
     sendFailureMessage: "发送问答卡片失败",
   })
 }
@@ -300,7 +300,7 @@ export async function handleCardAction(
     }
 
     if (!deps.v2Client) {
-      deps.log("warn", "v2Client 未配置，无法向 OpenCode 发起 abort", {
+      deps.log("warn", "OpenCode client 未配置，无法向 OpenCode 发起 abort", {
         runId: value.runId,
         sessionId: value.sessionId,
       })
@@ -328,7 +328,7 @@ export async function handleCardAction(
   }
 
   if (!deps.v2Client) {
-    deps.log("warn", "v2Client 未配置，交互回调被忽略（按钮点击不会转发到 OpenCode）", {
+    deps.log("warn", "OpenCode client 未配置，交互回调被忽略（按钮点击不会转发到 OpenCode）", {
       actionValue: action.actionValue,
     })
     return buildCallbackResponse(action, deps.log)


### PR DESCRIPTION
## Summary

兼容最新 OpenCode SDK v1.14.18，新增独立的 `message.part.delta` 事件处理，确保流式文本不依赖未定义行为。

## Changes

- **`event.ts`**: 新增 `case "message.part.delta":` 分支，独立处理文本增量（`delta`）事件
- **`event.ts`**: `message.part.updated` 只保留全量 `part.text` 快照兜底，移除 `(event.properties as { delta?: string }).delta` 强转
- **`interactive.ts`**: 清理 4 处日志措辞（"v2Client 未配置" → "OpenCode client 未配置"）
- **`package.json`**: 升级 `@opencode-ai/plugin` 1.1.53 → 1.14.18，bump 版本 1.7.10 → 1.7.11

## Root Cause

OpenCode 源码（`packages/opencode/src/session/message-v2.ts`）已将文本增量拆分为独立的 `message.part.delta` bus 事件。`EventMessagePartUpdated` 类型定义中不含 `delta` 字段，当前代码通过 `as` 强转读取属于未定义行为，可能在任何 SDK 版本更新中失效。

## Fix

- 新增 `message.part.delta` case 作为文本增量的主路径
- `message.part.updated` 降级为全量快照兜底（覆盖不发 delta 的 provider）
- 两种事件互补，不遗漏任何文本更新

## Test Plan

- `npm run build && npm run typecheck` 零错误
- 飞书单聊发送长文本请求，验证流式卡片文本逐字/逐段更新
- 群聊 @提及 bot，验证流式文本正常
- CardKit 不可用时的降级路径（`mirrorTextToMessage`）验证文本实时更新


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced real-time message streaming with improved delta handling for text updates.
  * Improved text buffer management for message parts.

* **Chores**
  * Version updated to 1.7.11.
  * Dependency updates applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->