### PR TITLE
feat: typed error taxonomy (spec 027)

### DIFF
--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------#
+#            Discover all capabilities of Qodana in our documentation           #
+#             https://www.jetbrains.com/help/qodana/about-qodana.html           #
+#-------------------------------------------------------------------------------#
+
+name: Qodana
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  qodana:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - name: 'Qodana Scan'
+        uses: JetBrains/qodana-action@v2025.3
+        env:
+          QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}
+        with:
+          # When pr-mode is set to true, Qodana analyzes only the files that have been changed
+          pr-mode: false
+          use-caches: true
+          post-pr-comment: true
+          use-annotations: true
+          # Upload Qodana results (SARIF, other artifacts, logs) as an artifact to the job
+          upload-result: false
+          # quick-fixes available in Ultimate and Ultimate Plus plans
+          push-fixes: 'none'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,399 +1,186 @@
 # AGENTS.md
 
-本文件为 Codex (Codex.ai/code) 在此代码仓库中工作时提供指导。
+## Project-Specific Guidelines
 
-## 项目概述
+opencode-feishu 是 **OpenCode 的飞书插件**（不是独立服务）。它通过飞书 WebSocket 长连接接收消息，原样转发给 OpenCode，并用 CardKit 2.0 流式卡片展示 AI 回复。插件**不解析命令、不选择模型**——只做消息中继和渠道适配。
 
-**opencode-feishu** 是 OpenCode 的飞书插件（不是独立服务），通过飞书 WebSocket 长连接接入本地 OpenCode Server。它支持流式响应和实时更新的 AI 对话。插件作为**消息中继**：所有消息（包括以 `/` 开头的命令）原样转发给 OpenCode，不解析命令、不选择模型。
+## 关键约定
 
-**核心能力：**
-- 飞书 WebSocket 长连接接收消息（无需 webhook）
-- 作为 OpenCode 插件运行（导出 `FeishuPlugin`，符合 `@opencode-ai/plugin` 接口）
-- 通过 OpenCode SDK `client` 管理会话和消息
-- 群聊静默监听（转发所有消息作为上下文，仅在被 @提及时回复）
-- 入群自动摄入历史消息
-- CardKit 2.0 流式卡片：AI 回复实时显示文本（markdown 渲染）和工具调用进度
-- 交互式卡片：权限审批和问答通过按钮完成（card.action.trigger WebSocket 回调）
-- 事件总线（action-bus）：per-session 事件订阅/发布，驱动流式卡片和交互卡片
-- Zod 配置验证：启动时结构化验证 feishu.json，拼写/类型错误立即报出
-- 通过插件 `event` 钩子接收 SSE 事件（message.part.updated、permission.asked、question.asked、session.idle）
-
-## 项目约定（重要）
-
-### 项目定位
-- **opencode-feishu 是 OpenCode 的插件，不是独立服务**
-- 作为 OpenCode 生态的一部分，由 OpenCode 加载和管理生命周期
-- 依赖 OpenCode Server 提供核心 AI 能力
-
-### 开发规范
-- **当前项目不需要单测** - 专注功能实现和集成测试
-- **所有文档包括 .specify 目录下尽量用中文编写**
-- **任何变更先改版本号** - 推荐使用 `npm run release` 自动完成版本更新、commit、tag 和 push，然后通过 PR 合并到 main。
-
-### Prompt/Skill 约定
-- 插件尽量保持透传，只负责渠道事实、展示控制和交互承载，不主动塑形 agent 的内容性输入输出。
-- `skills/<name>/prompt.md` 仅作为插件运行时 prompt 源文件，内容必须限制为最小事实、工具契约、渲染/回调约束和显式 non-goals。
-- `skills/<name>/SKILL.md` 是正式技能文档，用于发现、维护、评审和演进，**不得**整份注入飞书会话的 system prompt。
-- `prompt.md` **不得**写入“何时发卡”“标题/摘要/结论如何组织”“按钮如何措辞”“发送前自检”这类输出策略指令。
-
-详细项目约定参见：`.specify/memory/constitution.md`
+- **不需要写单测**——专注功能实现
+- **文档用中文**（包括 .specify 目录）
+- **任何变更先改版本号**——用 `npm run release`（bumpp 交互式选版本 + commit + tag + push）
+- **插件保持透传**——不主动塑形 agent 的内容性输入输出；`prompt.md` 只写最小事实和工具契约，不写输出策略指令
+- 详细约定见 `.specify/memory/constitution.md`
 
 ## 开发命令
 
-### 构建和开发
 ```bash
-# 安装依赖
-npm install
-
-# 构建（使用 tsup）
-npm run build
-
-# 开发模式（监听 + 重新构建）
-npm run dev
-
-# 仅类型检查
-npm run typecheck
+npm run build        # tsup 构建（ESM，Node 20 target）
+npm run dev          # tsup --watch
+npm run typecheck    # tsc --noEmit（无 lint 步骤）
+npm run release      # bumpp：选版本 → commit → tag → push
 ```
 
-### 发布
+验证变更：`npm run build && npm run typecheck`（项目无 lint/test 命令）。
+
+推送 `v*` tag 后 GitHub Actions 自动 `npm publish`（需 `NPM_TOKEN` secret）。
+
+## 本地调试
+
 ```bash
-# 一键版本发布（交互式选择 patch/minor/major，自动 commit + tag + push）
-npm run release
-
-# 手动发布（prepublishOnly 自动执行构建+类型检查）
-npm publish
-
-# 干运行：查看将要发布的文件（不实际发布）
-npm publish --dry-run
+FEISHU_DEBUG=1 opencode              # stderr 输出结构化 JSON
+FEISHU_DEBUG=1 opencode 2>debug.log  # 重定向到文件
 ```
 
-- `prepublishOnly` 脚本确保每次 `npm publish` 前自动运行 `build` 和 `typecheck`
-- `npm run release` 使用 bumpp 交互式选择版本，自动更新 package.json、创建 git commit 和 tag、推送到远程
-- 推送 `v*` tag 后 GitHub Actions 自动发布到 npm（需在 GitHub Secrets 中配置 `NPM_TOKEN`）
+## 安装到 OpenCode
 
-### 本地调试
-```bash
-# 启用调试模式（日志输出到 stderr）
-FEISHU_DEBUG=1 opencode
+1. `npm run build`
+2. `opencode.json` 中声明插件用**项目绝对路径**（不要用包名，Windows 上 Bun 安装有 EPERM 问题）：
+   ```json
+   { "plugin": ["D:/path/to/opencode-feishu"] }
+   ```
+3. 飞书配置 `~/.config/opencode/plugins/feishu.json`：`appId` + `appSecret`（必需）
 
-# 配合 Lark SDK 详细日志（feishu.json 中设置 "logLevel": "debug"）
-FEISHU_DEBUG=1 opencode
+## 构建配置要点
 
-# 过滤错误日志
-FEISHU_DEBUG=1 opencode 2>&1 | grep '"level":"error"'
+- **tsup**：ESM only，`splitting: false`，`treeshake: true`
+- **external**: `@opencode-ai/plugin`, `@opencode-ai/sdk`, `ws`
+- **noExternal**（打入 bundle）: `@larksuiteoapi/node-sdk`, `zod`
+- **peer deps**: `@opencode-ai/plugin >=1.1.0`, `@opencode-ai/sdk >=1.0.0`
+- 入口 `src/index.ts` 导出命名 `FeishuPlugin: Plugin`
 
-# 重定向到文件
-FEISHU_DEBUG=1 opencode 2>feishu-debug.log
+## 源码结构
+
+```
+src/
+  index.ts              # 插件入口：配置验证、Lark Client 创建、事件钩子注册
+  session.ts            # 飞书聊天 → OpenCode session 的稳定映射 + 缓存
+  types.ts              # Zod config schema + 共享类型
+  handler/              # 会话编排层（不碰飞书 SDK 细节）
+    chat.ts             # 核心对话处理：promptAsync → 流式卡片 → 轮询 + classify 唯一调用点
+    errors.ts           # 错误分类：PluginError 5 kinds + classify + matchPluginError
+    event.ts            # SSE 事件分发 + 错误缓存 + pendingBySession 管理
+    error-recovery.ts   # 模型错误自动恢复（消费已分类的 PluginError，上限 2 次）
+    session-queue.ts    # per-sessionKey FIFO 串行队列
+    action-bus.ts       # per-session 事件订阅/发布
+    interactive.ts      # 权限/问答交互卡片 + 按钮回调路由
+    reply-run-registry.ts # run 生命周期状态机 + abort 支持
+  feishu/               # 飞书渠道适配层（不碰会话编排逻辑）
+    gateway.ts          # WebSocket 网关：消息/卡片回调/bot入群事件
+    cardkit.ts          # CardKit 2.0 SDK 薄封装
+    streaming-card.ts   # 流式卡片生命周期管理
+    result-card-view.ts # 结果卡 JSON 模板构建
+    sender.ts           # 消息发送/更新/删除
+    content-extractor.ts # 飞书消息 → OpenCode PromptPart[] 翻译
+    resource.ts         # 文件/图片/音频下载 → data URL
+    quote.ts            # 引用消息内容获取
+    user-name.ts        # open_id → 用户名（24h TTL 缓存）
+    markdown.ts         # HTML 清理 + 28KB 截断
+    history.ts          # bot 入群历史摄入
+    session-chat-map.ts # sessionId → chatId 映射
+    dedup.ts            # 消息去重（默认 10 分钟窗口）
+    group-filter.ts     # @提及检测
+  tools/
+    send-card.ts        # feishu_send_card tool + 统一 DSL→CardKit JSON 翻译
+  utils/
+    ttl-map.ts          # 带 TTL 自动清理的 Map
+skills/
+  feishu-card-interaction/
+    prompt.md           # 运行时 prompt（注入飞书会话 system prompt）
+    SKILL.md            # 技能文档（不注入 system prompt）
 ```
 
-- `FEISHU_DEBUG=1`：启用 console.error 结构化 JSON 输出（不影响 stdout 管道）
-- `feishu.json` 中 `logLevel`：控制 Lark SDK 内部日志详细程度（`fatal`/`error`/`warn`/`info`/`debug`/`trace`）
-- 不设 `FEISHU_DEBUG` 时行为与之前完全一致（无 console 输出）
+## 关键跨文件契约（修改任一侧必须同步另一侧）
 
-### 安装到 OpenCode
+**`mirrorTextToMessage` flag**（chat.ts ↔ event.ts）：
+- CardKit 不可用时 chat.ts 发纯文本占位，注册 `mirrorTextToMessage: true`
+- event.ts 根据此 flag 决定走文本更新还是卡片更新路径
 
-**1. 构建插件：**
-```bash
-npm run build
+**`expectedMessageId` 首条锁**（event.ts 内部）：
+- 首个 SSE 事件锁定 messageID，后续不匹配的事件静默丢弃
+- 依赖 session-queue 的 FIFO 串行保证首个事件属于当前 run
+
+**`buildCardFromDSL`**（tools/send-card.ts）：
+- 同时被 agent tool 和权限/问答交互卡片复用
+- `ButtonInput.actionPayload` 有值时直接用作按钮 value（权限/问答），无值时构造 send_message action
+
+## 错误处理分层
+
+| 层 | 位置 | 职责 |
+|----|------|------|
+| L1 | event.ts | 从 `session.error` 提取错误消息，缓存到 sessionErrors（30s TTL） |
+| L2 | chat.ts pollForResponse | 每次轮询检查 SSE 缓存的错误，检测到立即终止 |
+| L3 | error-recovery.ts | `classify()` 判定 `ModelUnavailable` 时用全局默认模型重试（每 sessionKey 上限 2 次） |
+| L4 | session-queue.ts | per-sessionKey FIFO 防止消息竞态 |
+| L5 | event.ts | expectedMessageId 防止事件串扰 |
+
+错误消息统一由 chat.ts catch 块发送给用户（event.ts 不发送，避免双重发送）。
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
 ```
 
-**2. 在 `opencode.json` 中声明插件（使用项目绝对路径）：**
-```json
-{ "plugin": ["D:/path/to/opencode-feishu"] }
-```
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-> OpenCode 插件系统会将路径转换为 `file:///` 协议直接加载 `dist/index.js`。
-> 不要使用包名（如 `"opencode-feishu"`），Windows 上 Bun 安装存在 EPERM 权限问题。
+### 5. 消息流程
 
-**3. 创建飞书配置文件** `~/.config/opencode/plugins/feishu.json`：
-```json
-{ "appId": "cli_xxxxxxxxxxxx", "appSecret": "your_secret" }
-```
+| 场景 | 发送到 OpenCode | 飞书回复 |
+|------|:-:|:-:|
+| 单聊 | 是 | 是 |
+| 群聊 + @bot | 是 | 是 |
+| 群聊 + 未@bot | 是（noReply） | 否 |
+| Bot 入群（历史摄入） | 是（noReply） | 否 |
 
-## 架构设计
+---
 
-### 插件架构
-```
-OpenCode 加载插件 → src/index.ts (FeishuPlugin)
-    ├── Zod 配置验证 → FeishuConfigSchema.parse(feishu.json)
-    ├── Lark Client → SDK 内置 token 管理 + HTTP 客户端（中央创建，传递给 gateway/cardkit）
-    ├── CardKitClient → SDK thin wrapper（委托 client.cardkit.v1.*）
-    ├── fetchBotOpenId(larkClient) → client.request() 获取 bot open_id
-    └── startFeishuGateway(larkClient) → 启动 WebSocket 长连接（复用 Client）
-        ├── im.message.receive_v1 → enqueueMessage() [session-queue]
-        │   ├── shouldReply=false → handleChat() 静默转发（绕过队列）
-        │   └── shouldReply=true → 按 sessionKey 进入统一 FIFO 串行队列
-        │       └── handleChat(ctx, deps, signal?)
-        │           ├── StreamingCard.start() → 流式卡片（fallback 纯文本占位）
-        │           ├── subscribe(action-bus) → text/tool/permission/question 更新卡片
-        │           └── promptAsync() → 轮询（session.idle 提前退出）→ card.close()
-        ├── im.chat.member.bot.added_v1 → ingestGroupHistory()
-        └── card.action.trigger → handleCardAction() → v2Client.permission/question.reply()
-    event 钩子 → handleEvent()
-        ├── message.part.updated → 更新占位消息 + emit text-updated/tool-state-changed
-        ├── permission.asked → emit permission-requested（→ 交互卡片）
-        ├── question.asked → emit question-requested（→ 交互卡片）
-        ├── session.idle → emit session-idle（→ 轮询提前退出）
-        └── session.error → 缓存错误 + 模型不兼容时自动恢复会话
-```
-
-### 核心模块
-
-**插件入口 (`src/index.ts`):**
-- 导出 `FeishuPlugin: Plugin`（命名导出）
-- Zod 配置验证：`FeishuConfigSchema.parse()` 替代手动 `??` 合并，启动时报出清晰错误
-- 创建 `Lark.Client`（SDK 内置 token 管理），传递给 `CardKitClient` 和 `startFeishuGateway`
-- `fetchBotOpenId()` 使用 `larkClient.request()` 自动认证（无手动 token 管理）
-- `event` 钩子：接收 OpenCode 事件，处理 6+ 事件类型并通过 action-bus 分发
-- 使用 `client.app.log()` 记录结构化日志
-
-**飞书网关 (`src/feishu/gateway.ts`):**
-- 接收外部创建的 `Lark.Client`（复用 token 管理和 HTTP 客户端）
-- 创建 `WSClient`（WebSocket 长连接，独立代理配置）
-- 处理 `im.message.receive_v1` 事件
-- 处理 `card.action.trigger` 卡片回调（权限/问答按钮，3 秒内返回 toast）
-- 消息去重（默认 10 分钟，可通过 `dedupTtl` 配置，通过 `dedup.ts`）
-- 群消息 @提及过滤（通过 `group-filter.ts`）
-- 处理 `im.chat.member.bot.added_v1` 用于历史摄入
-
-**消息队列调度器 (`src/handler/session-queue.ts`):**
-- per-sessionKey FIFO 串行处理，防止占位消息/流式卡片并发覆盖
-- 单聊和群聊统一采用顺序消费模型，避免 IM 场景里的“新消息打断旧消息”造成残留撤回或丢回复
-- 静默消息（shouldReply=false）完全绕过队列
-- 队列只负责用户消息串行化；`session.idle` 之后的催促由 `event.ts` 的 nudge 逻辑驱动
-- 暴露 `enqueueMessage()` 作为唯一入口
-
-**对话处理器 (`src/handler/chat.ts`):**
-- 使用 `client.session.promptAsync()` 异步发送消息（不阻塞）
-- 接受可选 `signal?: AbortSignal` 参数，为轮询等待等可取消路径保留统一签名
-- 会话键格式：`feishu-p2p-<userId>` 或 `feishu-group-<chatId>`
-- 会话标题格式：`Feishu-<sessionKey>-<timestamp>`
-- 静默监听模式：`promptAsync({ noReply: true })`
-- 主动回复模式：`StreamingCard.start()` → action-bus 订阅 → 轮询（session.idle 提前退出）→ `card.close()`
-- action-bus 订阅：text-updated → 卡片文本更新、tool-state-changed → 工具进度、permission/question → 交互卡片
-- StreamingCard 回退：CardKit 创建失败时自动降级为纯文本占位消息
-
-**事件处理器 (`src/handler/event.ts`):**
-- 处理 `message.part.updated`：实时更新占位消息 + emit `text-updated`/`tool-state-changed` 到 action-bus
-- 处理 `permission.asked`/`question.asked`：emit 到 action-bus（→ 交互卡片）
-- 处理 `session.idle`：emit 到 action-bus（→ 轮询提前退出）
-- 处理 `session.error`：提取错误消息、缓存到 `sessionErrors` Map、检测模型不兼容错误
-- `isModelError()`：双层匹配策略 — 层1 精确子串（已知错误码），层2 关键词组合（"model" + 否定词，覆盖未知变体）
-- 管理 `pendingBySession` 映射（sessionId → 飞书占位消息）
-- 管理 `retryAttempts` 计数器（防止无限重试循环，上限 2 次）
-- 管理 `sessionErrors` 映射（30s TTL，供 chat.ts pollForResponse 和 catch 块消费）
-
-**事件总线 (`src/handler/action-bus.ts`):**
-- per-session 事件订阅/发布：`subscribe(sessionId, cb)` 返回 unsubscribe 函数
-- `emit(sessionId, action)` fire-and-forget 分发，错误不阻塞
-- `ProcessedAction` 联合类型：5 种事件（text-updated、tool-state-changed、permission-requested、question-requested、session-idle）
-
-**交互处理器 (`src/handler/interactive.ts`):**
-- `handlePermissionRequested`/`handleQuestionRequested`：使用 `buildCardFromDSL` 构建交互卡片并发送到飞书
-- `handleCardAction`：解析按钮回调 value → 路由到 v2Client permission/question reply
-- `seenRequestIds` 防止重复发送交互卡片
-- `buildCallbackResponse`：返回 toast 即时反馈（3 秒约束）
-- 权限/问答卡片通过 `actionPayload` 字段注入按钮回调数据，复用统一 DSL 构建路径
-
-**CardKit 客户端 (`src/feishu/cardkit.ts`):**
-- `CardKitClient` 类：SDK thin wrapper，委托 `client.cardkit.v1.*` 方法
-- `createCard(schema)` → `client.cardkit.v1.card.create()`
-- `updateElement(cardId, elementId, content, sequence)` → `client.cardkit.v1.cardElement.content()`
-- `closeStreaming(cardId, sequence)` → `client.cardkit.v1.card.settings()`
-- Token 管理由 SDK Client 内置处理，无需自定义 TokenManager
-
-**流式卡片 (`src/feishu/streaming-card.ts`):**
-- `StreamingCard` 类：管理单个 AI 回复的流式卡片生命周期
-- `start()` → 创建卡片 + 发送 interactive 消息
-- `updateText(delta)` / `setToolStatus(callID, tool, state)` → 队列串行化更新
-- `close(finalMarkdown?)` → 清理 markdown + 截断 + 关闭流式模式
-- `destroy()` → 删除消息（abort 场景）
-
-**Markdown 工具 (`src/feishu/markdown.ts`):**
-- `cleanMarkdown(text)`：移除 HTML 标签、确保代码块闭合
-- `truncateMarkdown(text, limit)`：截断到 28KB 并添加提示后缀
-
-**历史摄入 (`src/feishu/history.ts`):**
-- 通过飞书 API 按 `maxHistoryMessages` 拉取最近群消息（单次请求 50 条分页）
-- 以 `noReply: true` 发送到 OpenCode（仅上下文）
-
-**消息发送器 (`src/feishu/sender.ts`):**
-- 通过飞书 API 发送、更新和删除消息
-- `sendCardMessage(client, chatId, cardId)` — 发送 CardKit 流式卡片
-- `sendInteractiveCard(client, chatId, card)` — 发送交互式卡片（权限/问答）
-
-**Agent 卡片 Tool (`src/tools/send-card.ts`):**
-- `createSendCardTool(deps)` — 注册 `feishu_send_card` tool，agent 可自主发送结构化卡片
-- `buildCardFromDSL(args, chatId, chatType)` — 统一 DSL → CardKit 2.0 JSON 翻译（同时被 agent tool 和权限/问答卡片复用）
-- `ButtonInput.actionPayload` — 内部字段，有此字段时直接用作按钮 value（权限/问答场景），无时构造 send_message action
-- `SectionInput` — 支持 markdown/divider/note/actions 四种区块类型
-
-**会话-聊天映射 (`src/feishu/session-chat-map.ts`):**
-- `registerSessionChat(sessionId, chatId, chatType)` — 注册 sessionId → chatId 映射
-- `getChatIdBySession(sessionId)` — 查询映射
-- 供 feishu_send_card tool 和最小运行时 prompt 注入判定使用
-
-**辅助模块：**
-- `src/feishu/dedup.ts` - 消息去重窗口（默认 10 分钟，可通过 `dedupTtl` 配置）
-- `src/feishu/group-filter.ts` - @提及检测
-- `src/types.ts` - 类型定义（FeishuMessageContext, ResolvedConfig, LogFn, PermissionRequest, QuestionRequest）
-
-## 配置
-
-### 配置文件
-
-**1. OpenCode 插件声明**（`~/.config/opencode/opencode.json`，使用项目绝对路径）：
-```json
-{ "plugin": ["D:/path/to/opencode-feishu"] }
-```
-
-**2. 飞书配置**（`~/.config/opencode/plugins/feishu.json`）：
-```json
-{
-  "appId": "cli_xxxxxxxxxxxx",
-  "appSecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-}
-```
-
-必需字段：`appId`, `appSecret`
-可选字段：
-- `timeout`：对话轮询总超时（毫秒）；默认不设置固定超时。仅在显式配置时，超时后返回 `⚠️ 响应超时`
-- `thinkingDelay`：默认 `2500ms`
-- `logLevel`：默认 `"info"`，控制 Lark SDK 日志级别
-- `maxHistoryMessages`：默认 `200`，最大 `500`；飞书接口按每页 `50` 条分页拉取
-- `pollInterval`：默认 `1000ms`
-- `stablePolls`：默认 `3`
-- `dedupTtl`：默认 `600000ms`
-- `maxResourceSize`：默认 `500MB`，最大 `500MB`
-- `directory`：默认使用 OpenCode 当前工作目录（`ctx.directory`）；若 OpenCode 未提供则为空字符串；支持 `~` 和 `${ENV_VAR}` 展开
-- `nudge.enabled`：默认 `false`
-- `nudge.message`：默认“上一步操作已完成。请继续执行下一步，同步当前进度。如果全部完成，给出完整结果和结论。”
-- `nudge.intervalSeconds`：默认 `30`
-- `nudge.maxIterations`：默认 `3`
-- `nudge` 真实行为：仅在 `session.idle` 且最后一条 assistant message 以 `tool` part 结尾时，向 OpenCode 发送 `synthetic prompt`；不会直接向飞书用户新增一条可见消息
-
-## 群聊行为
-
-### 静默监听
-- 所有群消息都转发到 OpenCode 作为上下文（`noReply: true`）
-- Bot 仅在被直接 @提及时回复
-- 静默转发：不消耗 AI token，无可见的 bot 活动
-
-### @提及检测
-- 需要 bot 的 `open_id`（通过 `/open-apis/bot/v3/info` 获取）
-- 获取失败时直接抛出错误，阻止插件启动（严格模式）
-- 检测逻辑在 `src/feishu/group-filter.ts`
-
-### 入群历史摄入
-- 由 `im.chat.member.bot.added_v1` 事件触发
-- 按 `maxHistoryMessages` 拉取最近群消息（飞书接口按 50/页分页）
-- 以 `noReply: true` 发送所有消息到 OpenCode（仅上下文）
-
-## 消息流程变体
-
-| 场景 | 发送到 OpenCode | noReply | 飞书回复 |
-|------|:---------------:|:-------:|:--------:|
-| 单聊 (P2P) | 是 | 否 | 是 |
-| 群聊 + 被 @提及 | 是 | 否 | 是 |
-| 群聊 + 未被 @提及 | 是 | **是** | **否** |
-| Bot 加入群（历史） | 是 | **是** | **否** |
-| session.idle 催促 | 是（synthetic prompt） | 否 | 否（仅驱动 OpenCode 继续执行） |
-
-## TypeScript 配置
-
-- **目标**: ES2022
-- **模块**: ESNext + Bundler 解析
-- **构建工具**: tsup（ESM 输出，Node 20 目标）
-- **严格模式**: 启用
-- **输出**: `dist/` 目录，包含声明文件和源映射
-- **入口**: 库模式（无 shebang），导出 `FeishuPlugin`
-
-## 依赖项
-
-**运行时:**
-- `@larksuiteoapi/node-sdk`: 飞书 WebSocket 网关、REST API 客户端、内置 token 管理、CardKit 2.0 API
-- `zod`: 配置文件结构化验证
-- `https-proxy-agent`: WSClient 代理环境支持
-
-**Peer:**
-- `@opencode-ai/plugin`: OpenCode 插件接口（由 OpenCode 提供）
-
-**开发:**
-- `@opencode-ai/plugin`: 插件类型定义
-- `typescript`: 类型检查
-- `tsup`: 构建工具（基于 esbuild）
-- `@types/node`: Node.js 类型定义
-
-## 错误处理
-
-- `open_id` 获取失败：直接抛出错误，阻止插件启动
-- 提示超时：仅在显式配置 `timeout` 时，超时后返回"⚠️ 响应超时"
-- 消息去重：按 `dedupTtl` 窗口防止重复处理（默认 10 分钟）
-- 飞书消息发送失败：尽力更新占位消息，回退到发送新消息
-- 所有错误向飞书用户发送友好消息（不静默失败）
-
-### 会话错误处理（三层架构）
-
-**L1 错误提取**（event.ts）：从 `session.error` SSE 事件提取有意义的错误消息
-- `errMsg` 提取优先级：`e.message` → `data.message` → `e.type` → `e.name` → 兜底文案
-- `extractErrorFields()`：递归提取错误对象所有 string 值（最大深度 3），自动覆盖任何嵌套结构（data.message、data.error.code 等），无需手动维护字段名或层级
-- SDK `UnknownError` 类型的 `data.message` 是 required 字段，存放原始错误名
-
-**L2 轮询期间 SSE 错误检测**（chat.ts pollForResponse）：每次 poll 周期检查 `getSessionError()`
-- `pollForResponse()` 在 sleep 后、API 调用前检查 SSE 缓存的 session error
-- 检测到错误时抛出 `SessionErrorDetected` 异常（携带 sessionError 信息），立即终止轮询
-- 使模型异步失败（prompt 成功但模型报错）在下一次轮询（默认约 1 秒）内被检测，而非依赖固定超时
-
-**L3 模型不兼容自动恢复**（chat.ts）：检测模型错误时用全局默认模型重试
-- `getGlobalDefaultModel()`：通过 `client.config.get()` 读取 `Config.model` 字段（如 `"aigw/Codex-opus-4-6-v1"`），解析为 `{ providerID, modelID }`
-- 恢复策略：只用全局配置的默认模型，不在失败 provider 内搜索替代
-- 重试计数器：每 sessionKey 最多重试 2 次，防止无限循环；成功后重置计数
-- 全局默认模型未配置时，直接向用户显示错误，不重试
-
-**L4 并发控制**（session-queue.ts）：per-sessionKey FIFO 消息队列防止竞态
-- 单聊和群聊统一串行排队，保证同一逻辑会话里的消息顺序稳定
-- 静默消息绕过队列：`shouldReply=false` 直接转发，不受队列影响
-- 使用 `promptAsync()` 异步发送（不再有 prompt() HTTP 错误与 SSE 的竞态问题）
-- 错误消息统一由 chat.ts catch 块发送给用户（event.ts 不发送，避免双重发送）
-
-**L5 SSE 事件过滤**（event.ts）：messageID 防止事件串扰
-- `PendingReplyPayload.expectedMessageId`：首个 SSE 事件锁定 messageID，后续只接受匹配的事件
-- 串行队列保证首个事件属于当前请求
-
-## 日志记录
-
-- 通过 `client.app.log()` 输出到 OpenCode 日志系统（主日志通道）
-- 设置 `FEISHU_DEBUG=1` 环境变量时同时输出结构化 JSON 到 stderr（调试用）
-- 服务标识："opencode-feishu"
-- 级别：info、warn、error
-- 日志调用使用 `.catch(() => {})` 静默处理失败（防止 Unhandled Promise Rejection）
-
-## 常见开发场景
-
-### 添加新的消息事件处理器
-1. 修改 `src/feishu/gateway.ts` 注册新事件类型
-2. 在 `src/handler/` 中添加处理逻辑
-3. 在 `src/index.ts` 中连接处理器
-
-### 修改轮询行为
-- `feishu.json` 中配置 `pollInterval` 和 `stablePolls`
-- 调整以实现更快/更慢的响应检测
-
-### 调试事件流
-- 事件通过插件 `event` 钩子接收，逻辑在 `src/handler/event.ts`
-- 检查 `pendingBySession` 映射是否正确注册/注销
-
-### 测试静默监听
-- 发送群消息但不 @提及 bot
-- 检查日志中的"静默转发"条目
-- 验证无飞书回复但消息出现在 OpenCode 会话中
-
-## 重要约束
-
-- **不解析命令**：Bot 将所有消息（包括 `/commands`）原样转发给 OpenCode
-- **不选择模型/代理**：OpenCode 决定模型和代理路由
-- **不使用公网 webhook**：仅使用飞书 WebSocket 长连接
-- **单一 OpenCode 实例**：作为插件运行在 OpenCode 进程内
-- **会话恢复**：依赖标题前缀匹配（修改标题的会话可能无法恢复）
-- **消息去重**：按 `dedupTtl` 窗口处理，默认 10 分钟
-- **插件生命周期**：由 OpenCode 管理，无独立进程
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,68 @@
 # CLAUDE.md
 
-本文件为 Claude Code (claude.ai/code) 在此代码仓库中工作时提供指导。
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 通用编码准则
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## 项目概述
 
@@ -16,14 +78,9 @@
 - 交互式卡片：权限审批和问答通过按钮完成（card.action.trigger WebSocket 回调）
 - 事件总线（action-bus）：per-session 事件订阅/发布，驱动流式卡片和交互卡片
 - Zod 配置验证：启动时结构化验证 feishu.json，拼写/类型错误立即报出
-- 通过插件 `event` 钩子接收 SSE 事件（message.part.updated、permission.asked、question.asked、session.idle）
+- 通过插件 `event` 钩子接收 SSE 事件（message.part.updated、message.part.delta、message.updated、session.error、permission.asked、question.asked、session.idle）
 
 ## 项目约定（重要）
-
-### 项目定位
-- **opencode-feishu 是 OpenCode 的插件，不是独立服务**
-- 作为 OpenCode 生态的一部分，由 OpenCode 加载和管理生命周期
-- 依赖 OpenCode Server 提供核心 AI 能力
 
 ### 开发规范
 - **当前项目不需要单测** - 专注功能实现和集成测试
@@ -34,9 +91,19 @@
 - 插件尽量保持透传，只负责渠道事实、展示控制和交互承载，不主动塑形 agent 的内容性输入输出。
 - `skills/<name>/prompt.md` 仅作为插件运行时 prompt 源文件，内容必须限制为最小事实、工具契约、渲染/回调约束和显式 non-goals。
 - `skills/<name>/SKILL.md` 是正式技能文档，用于发现、维护、评审和演进，**不得**整份注入飞书会话的 system prompt。
-- `prompt.md` **不得**写入“何时发卡”“标题/摘要/结论如何组织”“按钮如何措辞”“发送前自检”这类输出策略指令。
+- `prompt.md` **不得**写入"何时发卡""标题/摘要/结论如何组织""按钮如何措辞""发送前自检"这类输出策略指令。
+- 当前 skills：`skills/feishu-card-interaction/`（含 `prompt.md` 运行时 system prompt 与 `SKILL.md` 技能文档）。
 
 详细项目约定参见：`.specify/memory/constitution.md`
+
+## Spec 驱动开发
+
+项目使用 `.specify/` 方法学管理需求和设计：
+
+- **`specs/<编号>-<名称>/`** — 每个 feature 的规格资产（spec.md、plan.md、tasks.md、checklists/）
+- **`.specify/memory/constitution.md`** — 项目级治理规则（测试策略、文档语言、错误处理分层等）
+- **`.specify/templates/`** — spec/plan/tasks 模板
+- **工作流**: `/speckit.specify` → `/speckit.clarify` → `/speckit.plan` → `/speckit.checklist` → 实现
 
 ## 目录级 CLAUDE.md
 
@@ -48,73 +115,40 @@
 
 ### 构建和开发
 ```bash
-# 安装依赖
-npm install
-
-# 构建（使用 tsup）
-npm run build
-
-# 开发模式（监听 + 重新构建）
-npm run dev
-
-# 仅类型检查
-npm run typecheck
+npm install              # 安装依赖
+npm run build            # 构建（tsup）
+npm run dev              # 监听模式
+npm run typecheck        # 仅类型检查
+npm run typecheck && npm run build   # 提交前自检（项目无 lint/test）
 ```
 
 ### 发布
 ```bash
-# 一键版本发布（交互式选择 patch/minor/major，自动 commit + tag + push）
-npm run release
-
-# 手动发布（prepublishOnly 自动执行构建+类型检查）
-npm publish
-
-# 干运行：查看将要发布的文件（不实际发布）
-npm publish --dry-run
+npm run release          # 交互式 bumpp：选版本 → commit → tag → push
+npm publish              # 手动发布（prepublishOnly 自动跑 build+typecheck）
+npm publish --dry-run    # 预览将发布文件
 ```
 
-- `prepublishOnly` 脚本确保每次 `npm publish` 前自动运行 `build` 和 `typecheck`
-- `npm run release` 使用 bumpp 交互式选择版本，自动更新 package.json、创建 git commit 和 tag、推送到远程
-- 推送 `v*` tag 后 GitHub Actions 自动发布到 npm（需在 GitHub Secrets 中配置 `NPM_TOKEN`）
+- 推送 `v*` tag 后 GitHub Actions 自动发布到 npm（需 `NPM_TOKEN` secret）
 
 ### 本地调试
 ```bash
-# 启用调试模式（日志输出到 stderr）
-FEISHU_DEBUG=1 opencode
-
-# 配合 Lark SDK 详细日志（feishu.json 中设置 "logLevel": "debug"）
-FEISHU_DEBUG=1 opencode
-
-# 过滤错误日志
-FEISHU_DEBUG=1 opencode 2>&1 | grep '"level":"error"'
-
-# 重定向到文件
-FEISHU_DEBUG=1 opencode 2>feishu-debug.log
+FEISHU_DEBUG=1 opencode                               # 启用 stderr JSON 日志
+FEISHU_DEBUG=1 opencode 2>&1 | grep '"level":"error"' # 过滤错误日志
+FEISHU_DEBUG=1 opencode 2>feishu-debug.log            # 重定向到文件
 ```
 
 - `FEISHU_DEBUG=1`：启用 console.error 结构化 JSON 输出（不影响 stdout 管道）
-- `feishu.json` 中 `logLevel`：控制 Lark SDK 内部日志详细程度（`fatal`/`error`/`warn`/`info`/`debug`/`trace`）
-- 不设 `FEISHU_DEBUG` 时行为与之前完全一致（无 console 输出）
+- `feishu.json` 中 `logLevel`：控制 Lark SDK 内部日志（`fatal`/`error`/`warn`/`info`/`debug`/`trace`）
 
 ### 安装到 OpenCode
 
-**1. 构建插件：**
-```bash
-npm run build
-```
-
-**2. 在 `opencode.json` 中声明插件（使用项目绝对路径）：**
-```json
-{ "plugin": ["D:/path/to/opencode-feishu"] }
-```
-
-> OpenCode 插件系统会将路径转换为 `file:///` 协议直接加载 `dist/index.js`。
-> 不要使用包名（如 `"opencode-feishu"`），Windows 上 Bun 安装存在 EPERM 权限问题。
-
-**3. 创建飞书配置文件** `~/.config/opencode/plugins/feishu.json`：
-```json
-{ "appId": "cli_xxxxxxxxxxxx", "appSecret": "your_secret" }
-```
+1. `npm run build`
+2. 在 `~/.config/opencode/opencode.json` 中声明插件（**使用项目绝对路径**，不用包名——Windows 上 Bun 安装有 EPERM 问题）：
+   ```json
+   { "plugin": ["D:/path/to/opencode-feishu"] }
+   ```
+3. 创建 `~/.config/opencode/plugins/feishu.json`（完整字段见下方"配置"）
 
 ## 架构设计
 
@@ -135,118 +169,57 @@ OpenCode 加载插件 → src/index.ts (FeishuPlugin)
         │           └── promptAsync() → 轮询（session.idle 提前退出）→ card.close()
         ├── im.chat.member.bot.added_v1 → ingestGroupHistory()
         └── card.action.trigger → handleCardAction() → v2Client.permission/question.reply()
+                                                        (v2Client = OpenCode v2 SDK client)
     event 钩子 → handleEvent()
-        ├── message.part.updated → 更新占位消息 + emit text-updated/tool-state-changed
+        ├── message.part.updated → 全量快照：更新占位消息 + emit text-updated/tool-state-changed
+        ├── message.part.delta → 增量 delta：拼接文本增量到 pendingBySession
+        ├── message.updated → emit assistant-meta-updated（模型/费用/耗时）
         ├── permission.asked → emit permission-requested（→ 交互卡片）
         ├── question.asked → emit question-requested（→ 交互卡片）
         ├── session.idle → emit session-idle（→ 轮询提前退出）
         └── session.error → 缓存错误 + 模型不兼容时自动恢复会话
 ```
 
-### 核心模块
+### 源码结构
 
-**插件入口 (`src/index.ts`):**
-- 导出 `FeishuPlugin: Plugin`（命名导出）
-- Zod 配置验证：`FeishuConfigSchema.parse()` 替代手动 `??` 合并，启动时报出清晰错误
-- 创建 `Lark.Client`（SDK 内置 token 管理），传递给 `CardKitClient` 和 `startFeishuGateway`
-- `fetchBotOpenId()` 使用 `larkClient.request()` 自动认证（无手动 token 管理）
-- `event` 钩子：接收 OpenCode 事件，处理 6+ 事件类型并通过 action-bus 分发
-- 使用 `client.app.log()` 记录结构化日志
+```
+src/
+  index.ts              # 插件入口：配置验证、Lark Client 创建、事件钩子注册
+  session.ts            # 飞书聊天 → OpenCode session 的稳定映射 + 缓存
+  types.ts              # Zod config schema + 共享类型
+  handler/              # 会话编排层（不碰飞书 SDK 细节）
+    chat.ts             # 核心对话处理：promptAsync → 流式卡片 → 轮询 + classify 唯一调用点
+    errors.ts           # 错误分类：PluginError 5 kinds + classify + matchPluginError
+    event.ts            # SSE 事件分发 + 错误缓存 + pendingBySession
+    error-recovery.ts   # 模型错误自动恢复（消费已分类的 PluginError）
+    session-queue.ts    # per-sessionKey FIFO 串行队列
+    action-bus.ts       # per-session 事件订阅/发布
+    interactive.ts      # 权限/问答交互卡片 + 按钮回调路由
+    reply-run-registry.ts # run 生命周期状态机 + abort 支持
+  feishu/               # 飞书渠道适配层（不碰会话编排逻辑）
+    gateway.ts cardkit.ts streaming-card.ts result-card-view.ts sender.ts
+    content-extractor.ts resource.ts quote.ts user-name.ts markdown.ts
+    history.ts session-chat-map.ts dedup.ts group-filter.ts
+  tools/
+    send-card.ts        # feishu_send_card tool + 统一 DSL→CardKit JSON 翻译
+  utils/
+    ttl-map.ts          # 带 TTL 自动清理的 Map
+skills/
+  feishu-card-interaction/
+    prompt.md SKILL.md
+```
 
-**飞书网关 (`src/feishu/gateway.ts`):**
-- 接收外部创建的 `Lark.Client`（复用 token 管理和 HTTP 客户端）
-- 创建 `WSClient`（WebSocket 长连接，独立代理配置）
-- 处理 `im.message.receive_v1` 事件
-- 处理 `card.action.trigger` 卡片回调（权限/问答按钮，3 秒内返回 toast）
-- 消息去重（默认 10 分钟，可通过 `dedupTtl` 配置，通过 `dedup.ts`）
-- 群消息 @提及过滤（通过 `group-filter.ts`）
-- 处理 `im.chat.member.bot.added_v1` 用于历史摄入
+每个子目录的 `CLAUDE.md` 包含该目录下每个文件的关键行为描述。
 
-**消息队列调度器 (`src/handler/session-queue.ts`):**
-- per-sessionKey FIFO 串行处理，防止占位消息/流式卡片并发覆盖
-- 单聊和群聊统一采用顺序消费模型，避免 IM 场景里的“新消息打断旧消息”造成残留撤回或丢回复
-- 静默消息（shouldReply=false）完全绕过队列
-- 队列只负责用户消息串行化；`session.idle` 之后的催促由 `event.ts` 的 nudge 逻辑驱动
-- 暴露 `enqueueMessage()` 作为唯一入口
+### 关键跨文件契约（修改任一侧必须同步另一侧）
 
-**对话处理器 (`src/handler/chat.ts`):**
-- 使用 `client.session.promptAsync()` 异步发送消息（不阻塞）
-- 接受可选 `signal?: AbortSignal` 参数，为轮询等待等可取消路径保留统一签名
-- 会话键格式：`feishu-p2p-<userId>` 或 `feishu-group-<chatId>`
-- 会话标题格式：`Feishu-<sessionKey>-<timestamp>`
-- 静默监听模式：`promptAsync({ noReply: true })`
-- 主动回复模式：`StreamingCard.start()` → action-bus 订阅 → 轮询（session.idle 提前退出）→ `card.close()`
-- action-bus 订阅：text-updated → 卡片文本更新、tool-state-changed → 工具进度、permission/question → 交互卡片
-- StreamingCard 回退：CardKit 创建失败时自动降级为纯文本占位消息
+**`buildCardFromDSL`**（tools/send-card.ts ↔ handler/interactive.ts）——唯一真跨目录契约：
+- 同时被 agent tool 和权限/问答交互卡片复用
+- `ButtonInput.actionPayload` 有值时直接用作按钮 value（权限/问答），无值时构造 send_message action
 
-**事件处理器 (`src/handler/event.ts`):**
-- 处理 `message.part.updated`：实时更新占位消息 + emit `text-updated`/`tool-state-changed` 到 action-bus
-- 处理 `permission.asked`/`question.asked`：emit 到 action-bus（→ 交互卡片）
-- 处理 `session.idle`：emit 到 action-bus（→ 轮询提前退出）
-- 处理 `session.error`：提取错误消息、缓存到 `sessionErrors` Map、检测模型不兼容错误
-- `isModelError()`：双层匹配策略 — 层1 精确子串（已知错误码），层2 关键词组合（"model" + 否定词，覆盖未知变体）
-- 管理 `pendingBySession` 映射（sessionId → 飞书占位消息）
-- 管理 `retryAttempts` 计数器（防止无限重试循环，上限 2 次）
-- 管理 `sessionErrors` 映射（30s TTL，供 chat.ts pollForResponse 和 catch 块消费）
-
-**事件总线 (`src/handler/action-bus.ts`):**
-- per-session 事件订阅/发布：`subscribe(sessionId, cb)` 返回 unsubscribe 函数
-- `emit(sessionId, action)` fire-and-forget 分发，错误不阻塞
-- `ProcessedAction` 联合类型：5 种事件（text-updated、tool-state-changed、permission-requested、question-requested、session-idle）
-
-**交互处理器 (`src/handler/interactive.ts`):**
-- `handlePermissionRequested`/`handleQuestionRequested`：使用 `buildCardFromDSL` 构建交互卡片并发送到飞书
-- `handleCardAction`：解析按钮回调 value → 路由到 v2Client permission/question reply
-- `seenRequestIds` 防止重复发送交互卡片
-- `buildCallbackResponse`：返回 toast 即时反馈（3 秒约束）
-- 权限/问答卡片通过 `actionPayload` 字段注入按钮回调数据，复用统一 DSL 构建路径
-
-**CardKit 客户端 (`src/feishu/cardkit.ts`):**
-- `CardKitClient` 类：SDK thin wrapper，委托 `client.cardkit.v1.*` 方法
-- `createCard(schema)` → `client.cardkit.v1.card.create()`
-- `updateElement(cardId, elementId, content, sequence)` → `client.cardkit.v1.cardElement.content()`
-- `closeStreaming(cardId, sequence)` → `client.cardkit.v1.card.settings()`
-- Token 管理由 SDK Client 内置处理，无需自定义 TokenManager
-
-**流式卡片 (`src/feishu/streaming-card.ts`):**
-- `StreamingCard` 类：管理单个 AI 回复的流式卡片生命周期
-- `start()` → 创建卡片 + 发送 interactive 消息
-- `updateText(delta)` / `setToolStatus(callID, tool, state)` → 队列串行化更新
-- `close(finalMarkdown?)` → 清理 markdown + 截断 + 关闭流式模式
-- `destroy()` → 删除消息（abort 场景）
-
-**Markdown 工具 (`src/feishu/markdown.ts`):**
-- `cleanMarkdown(text)`：移除 HTML 标签、确保代码块闭合
-- `truncateMarkdown(text, limit)`：截断到 28KB 并添加提示后缀
-
-**历史摄入 (`src/feishu/history.ts`):**
-- 通过飞书 API 按 `maxHistoryMessages` 拉取最近群消息（单次请求 50 条分页）
-- 以 `noReply: true` 发送到 OpenCode（仅上下文）
-
-**消息发送器 (`src/feishu/sender.ts`):**
-- 通过飞书 API 发送、更新和删除消息
-- `sendCardMessage(client, chatId, cardId)` — 发送 CardKit 流式卡片
-- `sendInteractiveCard(client, chatId, card)` — 发送交互式卡片（权限/问答）
-
-**Agent 卡片 Tool (`src/tools/send-card.ts`):**
-- `createSendCardTool(deps)` — 注册 `feishu_send_card` tool，agent 可自主发送结构化卡片
-- `buildCardFromDSL(args, chatId, chatType)` — 统一 DSL → CardKit 2.0 JSON 翻译（同时被 agent tool 和权限/问答卡片复用）
-- `ButtonInput.actionPayload` — 内部字段，有此字段时直接用作按钮 value（权限/问答场景），无时构造 send_message action
-- `SectionInput` — 支持 markdown/divider/note/actions 四种区块类型
-
-**会话-聊天映射 (`src/feishu/session-chat-map.ts`):**
-- `registerSessionChat(sessionId, chatId, chatType)` — 注册 sessionId → chatId 映射
-- `getChatIdBySession(sessionId)` — 查询映射
-- 供 feishu_send_card tool 和最小运行时 prompt 注入判定使用
-
-**辅助模块：**
-- `src/feishu/dedup.ts` - 消息去重窗口（默认 10 分钟，可通过 `dedupTtl` 配置）
-- `src/feishu/group-filter.ts` - @提及检测
-- `src/types.ts` - 类型定义（FeishuMessageContext, ResolvedConfig, LogFn, PermissionRequest, QuestionRequest）
+handler 内部契约（`mirrorTextToMessage`、`expectedMessageId` 首条锁）详见 `src/handler/CLAUDE.md`。
 
 ## 配置
-
-### 配置文件
 
 **1. OpenCode 插件声明**（`~/.config/opencode/opencode.json`）：
 ```json
@@ -262,7 +235,7 @@ OpenCode 加载插件 → src/index.ts (FeishuPlugin)
 ```
 
 必需字段：`appId`, `appSecret`
-可选字段：
+可选字段（**source of truth: `src/types.ts` 的 `FeishuConfigSchema`**）：
 - `timeout`：对话轮询总超时（毫秒）；默认不设置固定超时。仅在显式配置时，超时后返回 `⚠️ 响应超时`
 - `thinkingDelay`：默认 `2500ms`
 - `logLevel`：默认 `"info"`，控制 Lark SDK 日志级别
@@ -273,27 +246,10 @@ OpenCode 加载插件 → src/index.ts (FeishuPlugin)
 - `maxResourceSize`：默认 `500MB`，最大 `500MB`
 - `directory`：默认使用 OpenCode 当前工作目录（`ctx.directory`）；若 OpenCode 未提供则为空字符串；支持 `~` 和 `${ENV_VAR}` 展开
 - `nudge.enabled`：默认 `false`
-- `nudge.message`：默认“上一步操作已完成。请继续执行下一步，同步当前进度。如果全部完成，给出完整结果和结论。”
+- `nudge.message`：默认"上一步操作已完成。请继续执行下一步，同步当前进度。如果全部完成，给出完整结果和结论。"
 - `nudge.intervalSeconds`：默认 `30`
 - `nudge.maxIterations`：默认 `3`
 - `nudge` 真实行为：仅在 `session.idle` 且最后一条 assistant message 以 `tool` part 结尾时，向 OpenCode 发送 `synthetic prompt`；不会直接向飞书用户新增一条可见消息
-
-## 群聊行为
-
-### 静默监听
-- 所有群消息都转发到 OpenCode 作为上下文（`noReply: true`）
-- Bot 仅在被直接 @提及时回复
-- 静默转发：不消耗 AI token，无可见的 bot 活动
-
-### @提及检测
-- 需要 bot 的 `open_id`（通过 `/open-apis/bot/v3/info` 获取）
-- 获取失败时直接抛出错误，阻止插件启动（严格模式）
-- 检测逻辑在 `src/feishu/group-filter.ts`
-
-### 入群历史摄入
-- 由 `im.chat.member.bot.added_v1` 事件触发
-- 按 `maxHistoryMessages` 拉取最近群消息（飞书接口按 50/页分页）
-- 以 `noReply: true` 发送所有消息到 OpenCode（仅上下文）
 
 ## 消息流程变体
 
@@ -302,33 +258,13 @@ OpenCode 加载插件 → src/index.ts (FeishuPlugin)
 | 单聊 (P2P) | 是 | 否 | 是 |
 | 群聊 + 被 @提及 | 是 | 否 | 是 |
 | 群聊 + 未被 @提及 | 是 | **是** | **否** |
-| Bot 加入群（历史） | 是 | **是** | **否** |
+| Bot 加入群（历史摄入） | 是 | **是** | **否** |
 | session.idle 催促 | 是（synthetic prompt） | 否 | 否（仅驱动 OpenCode 继续执行） |
 
-## TypeScript 配置
-
-- **目标**: ES2022
-- **模块**: ESNext + Bundler 解析
-- **构建工具**: tsup（ESM 输出，Node 20 目标）
-- **严格模式**: 启用
-- **输出**: `dist/` 目录，包含声明文件和源映射
-- **入口**: 库模式（无 shebang），导出 `FeishuPlugin`
-
-## 依赖项
-
-**运行时:**
-- `@larksuiteoapi/node-sdk`: 飞书 WebSocket 网关、REST API 客户端、内置 token 管理、CardKit 2.0 API
-- `zod`: 配置文件结构化验证
-- `https-proxy-agent`: WSClient 代理环境支持
-
-**Peer:**
-- `@opencode-ai/plugin`: OpenCode 插件接口（由 OpenCode 提供）
-
-**开发:**
-- `@opencode-ai/plugin`: 插件类型定义
-- `typescript`: 类型检查
-- `tsup`: 构建工具（基于 esbuild）
-- `@types/node`: Node.js 类型定义
+**群聊行为关键点**（实现细节见 `src/feishu/CLAUDE.md`）：
+- @提及检测依赖 bot 的 `open_id`（启动时通过 `/open-apis/bot/v3/info` 获取，失败直接阻止插件启动）
+- 历史摄入由 `im.chat.member.bot.added_v1` 入群事件触发，按 `maxHistoryMessages` 分页拉取
+- 群聊未被 @提及时仍全量转发给 OpenCode 作为上下文（`noReply: true`），不消耗 AI token
 
 ## 错误处理
 
@@ -338,61 +274,17 @@ OpenCode 加载插件 → src/index.ts (FeishuPlugin)
 - 飞书消息发送失败：尽力更新占位消息，回退到发送新消息
 - 所有错误向飞书用户发送友好消息（不静默失败）
 
-### 会话错误处理（三层架构）
+### 会话错误处理（五层架构）
 
-**L1 错误提取**（event.ts）：从 `session.error` SSE 事件提取有意义的错误消息
-- `errMsg` 提取优先级：`e.message` → `data.message` → `e.type` → `e.name` → 兜底文案
-- `extractErrorFields()`：递归提取错误对象所有 string 值（最大深度 3），自动覆盖任何嵌套结构（data.message、data.error.code 等），无需手动维护字段名或层级
-- SDK `UnknownError` 类型的 `data.message` 是 required 字段，存放原始错误名
+| 层 | 位置 | 职责 |
+|----|------|------|
+| L1 | event.ts | 从 `session.error` 提取错误消息 + raw error，缓存到 sessionErrors（30s TTL） |
+| L2 | chat.ts pollForResponse | 每次轮询检查 SSE 缓存的错误，检测到立即终止 |
+| L3 | error-recovery.ts | `classify()` 判定 `ModelUnavailable` 时用全局默认模型重试（每 sessionKey 上限 2 次） |
+| L4 | session-queue.ts | per-sessionKey FIFO 防止消息竞态 |
+| L5 | event.ts | `expectedMessageId` 首条锁防止事件串扰 |
 
-**L2 轮询期间 SSE 错误检测**（chat.ts pollForResponse）：每次 poll 周期检查 `getSessionError()`
-- `pollForResponse()` 在 sleep 后、API 调用前检查 SSE 缓存的 session error
-- 检测到错误时抛出 `SessionErrorDetected` 异常（携带 sessionError 信息），立即终止轮询
-- 使模型异步失败（prompt 成功但模型报错）在下一次轮询（默认约 1 秒）内被检测，而非依赖固定超时
-
-**L3 模型不兼容自动恢复**（chat.ts）：检测模型错误时用全局默认模型重试
-- `getGlobalDefaultModel()`：通过 `client.config.get()` 读取 `Config.model` 字段（如 `"aigw/claude-opus-4-6-v1"`），解析为 `{ providerID, modelID }`
-- 恢复策略：只用全局配置的默认模型，不在失败 provider 内搜索替代
-- 重试计数器：每 sessionKey 最多重试 2 次，防止无限循环；成功后重置计数
-- 全局默认模型未配置时，直接向用户显示错误，不重试
-
-**L4 并发控制**（session-queue.ts）：per-sessionKey FIFO 消息队列防止竞态
-- 单聊和群聊统一串行排队，保证同一逻辑会话里的消息顺序稳定
-- 静默消息绕过队列：`shouldReply=false` 直接转发，不受队列影响
-- 使用 `promptAsync()` 异步发送（不再有 prompt() HTTP 错误与 SSE 的竞态问题）
-- 错误消息统一由 chat.ts catch 块发送给用户（event.ts 不发送，避免双重发送）
-
-**L5 SSE 事件过滤**（event.ts）：messageID 防止事件串扰
-- `PendingReplyPayload.expectedMessageId`：首个 SSE 事件锁定 messageID，后续只接受匹配的事件
-- 串行队列保证首个事件属于当前请求
-
-## 日志记录
-
-- 通过 `client.app.log()` 输出到 OpenCode 日志系统（主日志通道）
-- 设置 `FEISHU_DEBUG=1` 环境变量时同时输出结构化 JSON 到 stderr（调试用）
-- 服务标识："opencode-feishu"
-- 级别：info、warn、error
-- 日志调用使用 `.catch(() => {})` 静默处理失败（防止 Unhandled Promise Rejection）
-
-## 常见开发场景
-
-### 添加新的消息事件处理器
-1. 修改 `src/feishu/gateway.ts` 注册新事件类型
-2. 在 `src/handler/` 中添加处理逻辑
-3. 在 `src/index.ts` 中连接处理器
-
-### 修改轮询行为
-- `feishu.json` 中配置 `pollInterval` 和 `stablePolls`
-- 调整以实现更快/更慢的响应检测
-
-### 调试事件流
-- 事件通过插件 `event` 钩子接收，逻辑在 `src/handler/event.ts`
-- 检查 `pendingBySession` 映射是否正确注册/注销
-
-### 测试静默监听
-- 发送群消息但不 @提及 bot
-- 检查日志中的"静默转发"条目
-- 验证无飞书回复但消息出现在 OpenCode 会话中
+各层实现细节参见 `src/handler/CLAUDE.md`。
 
 ## 重要约束
 
@@ -403,3 +295,4 @@ OpenCode 加载插件 → src/index.ts (FeishuPlugin)
 - **会话恢复**：依赖标题前缀匹配（修改标题的会话可能无法恢复）
 - **消息去重**：按 `dedupTtl` 窗口处理，默认 10 分钟
 - **插件生命周期**：由 OpenCode 管理，无独立进程
+- **会话中毒恢复**：检测到结构性错误（如不兼容的 file part、tool schema）时调用 `client.session.create()` 开一条**全新空白** session（**不是 fork**，**不保留历史对话**）；旧 session 在 OpenCode server 上仍存在但插件不再引用。用户需重新发送消息，上下文丢失是此策略的有意代价——fork 会复制中毒历史导致死循环。

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,0 +1,49 @@
+#-------------------------------------------------------------------------------#
+#               Qodana analysis is configured by qodana.yaml file               #
+#             https://www.jetbrains.com/help/qodana/qodana-yaml.html            #
+#-------------------------------------------------------------------------------#
+
+#################################################################################
+#              WARNING: Do not store sensitive information in this file,        #
+#               as its contents will be included in the Qodana report.          #
+#################################################################################
+version: "1.0"
+
+#Specify inspection profile for code analysis
+profile:
+  name: qodana.starter
+
+#Enable inspections
+#include:
+#  - name: <SomeEnabledInspectionId>
+
+#Disable inspections
+#exclude:
+#  - name: <SomeDisabledInspectionId>
+#    paths:
+#      - <path/where/not/run/inspection>
+
+projectJDK: "21" #(Applied in CI/CD pipeline)
+
+#Execute shell command before Qodana execution (Applied in CI/CD pipeline)
+#bootstrap: sh ./prepare-qodana.sh
+
+#Install IDE plugins before Qodana execution (Applied in CI/CD pipeline)
+#plugins:
+#  - id: <plugin.id> #(plugin id can be found at https://plugins.jetbrains.com)
+
+# Quality gate. Will fail the CI/CD pipeline if any condition is not met
+# severityThresholds - configures maximum thresholds for different problem severities
+# testCoverageThresholds - configures minimum code coverage on a whole project and newly added code
+# Code Coverage is available in Ultimate and Ultimate Plus plans
+#failureConditions:
+#  severityThresholds:
+#    any: 15
+#    critical: 5
+#  testCoverageThresholds:
+#    fresh: 70
+#    total: 50
+  
+#Qodana supports other languages, for example, Python, JavaScript, TypeScript, Go, C#, PHP
+#For all supported languages see https://www.jetbrains.com/help/qodana/linters.html
+linter: jetbrains/qodana-jvm-community:2025.3

--- a/src/feishu/CLAUDE.md
+++ b/src/feishu/CLAUDE.md
@@ -19,6 +19,103 @@
 - 用户可见卡片中的主内容应来自上游显式内容或稳定快照投影。
 - 这里允许存在 UI 壳层文案和渠道协议字段，但不应扩展成内容重写层。
 
+## 文件职责
+
+**gateway.ts** — WebSocket 网关
+- 创建 WSClient（WebSocket 长连接），处理 im.message.receive_v1 消息事件并组装 FeishuMessageContext
+- 处理 card.action.trigger 卡片回调（权限/问答按钮，3 秒内返回 toast）
+- 处理 im.chat.member.bot.added_v1 入群事件，触发历史摄入
+- 消息去重（dedup.ts）+ 群消息 @提及过滤（group-filter.ts）+ 代理环境支持
+
+**cardkit.ts** — CardKit 2.0 SDK 薄封装
+- 封装 `client.cardkit.v1.card.create()` 创建卡片实体并返回 card_id
+- 封装 `client.cardkit.v1.cardElement.content()` 更新卡片元素内容
+- 封装 `client.cardkit.v1.card.settings()` 关闭流式模式
+- 统一提取 SDK 底层 HTTP 响应体作为错误诊断信息
+
+**streaming-card.ts** — 流式卡片生命周期管理
+- 管理单次 AI 回复对应的结构化结果卡（创建 → 更新 → 关闭）
+- 维护串行更新队列，保证多次异步更新按顺序执行
+- 累积文本、工具状态、详细步骤快照，通过 result-card-view 渲染为 CardKit JSON
+- CardKit 更新失败后进入 degraded 状态，UI 不再刷新但仍累积内存数据
+
+**result-card-view.ts** — 结果卡 JSON 模板构建
+- 构建 ReplyCardView（标题/紧凑状态/结论/详细步骤/动作区），转换为 CardKit schema
+- 从 PromptPart 提炼标题、从 ReplyRunState 推导紧凑状态文案和头部模板颜色
+- 构建工具调用详细步骤 markdown（折叠面板）和中止按钮动作元素
+- 简单降级模式下生成纯文本兜底内容
+
+**sender.ts** — 飞书消息发送/更新/删除
+- 封装 `im.message.create` 统一发送文本消息、交互卡片和 CardKit 卡片
+- 封装 `im.message.patch` 更新已有消息内容
+- 封装 `im.message.delete` 删除消息（用于 abort 场景销毁占位卡片）
+- 所有操作返回统一 `FeishuSendResult` 结构，自动提取 Lark SDK 错误诊断字段
+
+**content-extractor.ts** — 飞书消息 → OpenCode PromptPart 翻译
+- 按消息类型（text/image/post/file/audio/sticker 等）分发到专用提取函数
+- 将飞书富文本（post）和交互卡片（interactive）解析为纯文本或文件 part
+- 下载图片/文件/音频资源并转为 data URL 嵌入 file part
+- 对不支持的消息类型生成占位文本（如 `[不支持的消息类型: xxx]`）
+
+**resource.ts** — 飞书资源下载
+- 通过 `im.messageResource.get` 流式下载消息中的图片/文件/音频
+- 边下载边统计字节大小，超过 `maxResourceSize` 立即中断并返回 `too_large` 结果
+- 将下载内容转为 `data:<mime>;base64,<data>` 格式的 data URL
+- 根据文件扩展名猜测 MIME 类型（`guessMimeByFilename`）
+
+**quote.ts** — 引用消息内容获取
+- 通过 `im.message.get` 读取被引用消息的原始内容
+- 将引用消息转换为人类可读的文本描述（复用 content-extractor 的 `describeMessageType`）
+- 截断到 500 字符安全长度，防止超长引用撑爆上下文
+- 获取失败时静默返回 undefined，不阻断主流程
+
+**user-name.ts** — open_id → 用户名解析
+- 通过飞书通讯录 API（`contact.user.get`）将 open_id 解析为真实姓名
+- 使用 24 小时 TTL 缓存（TtlMap）避免重复请求
+- 解析失败时回退返回原始 open_id，不阻断主流程
+
+**markdown.ts** — HTML 清理 + 28KB 截断
+- 移除 AI 输出中的 HTML 标签（保护代码块中的泛型语法如 `Map<string, number>`）
+- 确保代码块正确闭合（流式输出可能在代码块中间截断）
+- 按 UTF-8 字节截断到 28KB（预留 2KB 给飞书 ~30KB 上限），尽量在完整行处截断
+- 截断后追加 `*内容过长，已截断*` 提示后缀
+
+**history.ts** — bot 入群历史摄入
+- 通过飞书 `im.message.list` 分页拉取群聊最近消息（每页 50 条，上限由 `maxHistoryMessages` 控制）
+- 过滤已删除和空内容消息，将各消息类型转为人类可读文本
+- 以 `noReply: true` 格式化注入 OpenCode 会话，仅提供上下文不触发 AI 回复
+
+**session-chat-map.ts** — sessionId → chatId 映射
+- 维护 OpenCode sessionId 到飞书 chatId + chatType 的映射关系
+- 使用 24 小时 TTL 缓存（TtlMap）自动清理过期条目
+- 供 feishu_send_card tool 和最小运行时 prompt 注入判定使用
+
+**dedup.ts** — 消息去重
+- 使用 TtlMap 记录已处理的 messageId，默认 10 分钟窗口内自动去重
+- 防止飞书 WebSocket 在网络抖动或重连时重复投递同一事件
+- 通过 `initDedup(ttl)` 支持启动时自定义去重窗口
+
+**group-filter.ts** — @提及检测
+- 遍历飞书消息 mentions 数组，与 bot 自身的 open_id 比较
+- 群聊中仅在 bot 被直接 @提及时返回 true，决定是否生成 AI 回复
+
+## 群聊行为
+
+### 静默监听
+- 所有群消息都转发到 OpenCode 作为上下文（`noReply: true`）
+- Bot 仅在被直接 @提及时回复
+- 静默转发：不消耗 AI token，无可见的 bot 活动
+
+### @提及检测
+- 需要 bot 的 `open_id`（通过 `/open-apis/bot/v3/info` 获取）
+- 获取失败时直接抛出错误，阻止插件启动（严格模式）
+- 检测逻辑在 `group-filter.ts`
+
+### 入群历史摄入
+- 由 `im.chat.member.bot.added_v1` 事件触发
+- 按 `maxHistoryMessages` 拉取最近群消息（飞书接口按 50/页分页）
+- 以 `noReply: true` 发送所有消息到 OpenCode（仅上下文）
+
 ## 降级语义说明
 
 - `StreamingCard` 任一 CardKit 更新抛错后进入 `degraded` 状态。

--- a/src/handler/CLAUDE.md
+++ b/src/handler/CLAUDE.md
@@ -19,6 +19,96 @@
 - 对输入的增强仅限明确记录的最小必要上下文增强。
 - 对输出的加工仅限状态控制、终态冻结和展示投影，不应发展为语义总结器。
 
+## 文件职责
+
+**chat.ts** — 核心对话处理器
+- `handleChat()` 完整走完一条飞书消息：绑定 session → 构造 prompt → `promptAsync()` 异步发送 → 轮询等待输出稳定 → 写回飞书
+- 启动 StreamingCard（CardKit 不可用时降级为纯文本占位），通过 action-bus 订阅 text-updated / tool-state-changed / permission / question 事件实时更新卡片
+- 轮询期间每轮检查 SSE 缓存错误，检测到 `SessionErrorDetected` 立即终止
+- catch 块是 `classify()` 的**唯一调用点**（FR-011）：通过 `matchPluginError` exhaustive handler 分发到具体错误处理路径
+
+**event.ts** — SSE 事件分发与状态缓存
+- `handleEvent()` 接收 OpenCode 事件，按类型分发：`message.part.updated` 更新占位消息或卡片，`permission.asked` / `question.asked` / `session.idle` 转发到 action-bus
+- 维护 `pendingBySession` 映射（sessionId → 占位消息上下文），管理 `expectedMessageId` 首条 SSE 锁防止事件串线
+- 缓存 `sessionErrors`（30s TTL，含 raw error 对象）和 `retryAttempts` 计数器，供 chat.ts 和 error-recovery.ts 消费
+
+**session-queue.ts** — per-sessionKey FIFO 串行队列
+- 按 sessionKey 归并消息，同一逻辑会话内严格串行消费，防止占位消息/流式卡片并发覆盖
+- `enqueueMessage()` 是唯一入口；`shouldReply=false` 的静默消息直接透传，不占用队列
+- 队列空闲时自动回收状态对象，避免长时间运行后空壳条目积累
+
+**action-bus.ts** — per-session 轻量事件总线
+- `subscribe(sessionId, cb)` 注册订阅，返回幂等的 unsubscribe 函数；最后一个订阅者移除后清理空集合
+- `emit(sessionId, action)` fire-and-forget 广播，单个订阅者抛错不阻塞其他订阅者也不打断主流程
+- `ProcessedAction` 联合类型覆盖 7 种事件：text-updated、details-updated、tool-state-changed、permission-requested、question-requested、session-idle、assistant-meta-updated
+
+**interactive.ts** — 权限/问答交互卡片与按钮回调
+- `handlePermissionRequested()` / `handleQuestionRequested()` 使用 `buildCardFromDSL` 构建交互卡片并发送到飞书，`seenIds` TtlMap 防止重复发送
+- `handleCardAction()` 解析卡片按钮回调 value → 路由到 v2Client 的 permission / question / abort reply
+- `buildCallbackResponse()` 返回 toast 即时反馈（飞书 3 秒约束），abort 按钮通过 reply-run-registry 管理取消流程
+
+**errors.ts** — 错误分类（typed discriminated union）
+- `classify(raw): PluginError` 纯函数，按优先级链判定：Auth → Context → Model → Poison → fallback
+- `matchPluginError(err, handlers)` exhaustive matcher，漏 kind 直接编译报错
+- `toLog(err)` 安全日志 payload，不暴露 raw（防 secrets 泄漏）
+- `PluginErrorThrown` nominal wrapper，仅 throw/catch 边界使用
+- 类型：`PluginError`（5 kinds）、`Evidence[]`、`RuleName`、`FieldPath`
+
+**error-recovery.ts** — 模型错误自动恢复
+- `tryModelRecovery()` 接收已分类的 `PluginError & { kind: "ModelUnavailable" }`，用全局默认模型自动重试（每 sessionKey 上限 2 次，成功后重置计数）
+- `SessionErrorDetected` 专用异常类，使轮询期间发现的 SSE 错误与普通异常可区分
+- `extractSessionError()` 从异常或 SSE 缓存中提取结构化错误，取到后立即清理缓存避免污染下一轮调用
+
+**reply-run-registry.ts** — run 生命周期状态机与 abort 支持
+- 管理 `ActiveReplyRun` 对象的创建、状态流转（starting → running → completing → completed/failed/timed_out/aborted）和 TTL 自动清理
+- 通过 `activeBySessionKey` / `runsByRunId` / `runsBySessionId` 三张 TtlMap 提供多维度查找
+- `requestAbortForRun()` 设置 abort 请求并切换状态到 aborting，`confirmAbortForRun()` / `resetAbortForRun()` 处理确认和回滚
+- 每个 run 持有独立的 `AbortController`，`getRunAbortSignal()` 供轮询等可取消路径消费
+
+## 会话错误处理（五层架构）
+
+| 层 | 位置 | 职责 |
+|----|------|------|
+| L1 | event.ts | 从 `session.error` 提取错误消息 + raw error，缓存到 sessionErrors（30s TTL） |
+| L2 | chat.ts pollForResponse | 每次轮询检查 SSE 缓存的错误，检测到立即终止 |
+| L3 | error-recovery.ts | `classify()` 判定 `ModelUnavailable` 时用全局默认模型重试（每 sessionKey 上限 2 次） |
+| L4 | session-queue.ts | per-sessionKey FIFO 防止消息竞态 |
+| L5 | event.ts | expectedMessageId 防止事件串扰 |
+
+错误消息统一由 chat.ts catch 块发送给用户（event.ts 不发送，避免双重发送）。
+
+**Phase 0 临时日志**：`session.error.raw-shape` 记录完整 error 形状（name、keys、data.message），用于 spec 027 真实样本采集。此日志在 027 主 PR 合入后删除。
+
+**L1** event.ts 缓存 raw error 对象 + 提取消息字符串。`classify()` 在 chat.ts catch 块中消费 raw error，按优先级链判定 kind。
+
+**L2** `pollForResponse()` 每次轮询检查 SSE 缓存错误，检测到立即终止（~1s 内）。
+
+**错误分类规则优先级**（`errors.ts` classify 链）：
+
+| 优先级 | 规则函数 | 命中条件 | 证据强度 |
+|-------|---------|---------|---------|
+| 1 | `tryUnauthorized` | `raw.name === "ProviderAuthError"` | ⭐⭐⭐ 强 |
+| 2 | `tryContextOverflow` | `raw.name === "ContextOverflowError"` | ⭐⭐⭐ 强 |
+| 3 | `tryModelUnavailable` | `raw.name === "ProviderModelNotFoundError"` OR `UnknownError` + pattern | ⭐⭐ 中 |
+| 4 | `trySessionPoisoned` | `raw.name` ∈ 白名单 AND `data.message` matches pattern（two-factor） | ⭐ 弱 |
+| ∞ | fallback | 其余 → `UnknownUpstream` | — |
+
+**中毒恢复**：`classify()` 判定 `SessionPoisoned` 后，chat.ts 调 `invalidateSession(sessionKey)`——仅清本地缓存 + 置 `forceCreateSession` 标记；下一条用户消息触发 `client.session.create()` 开**全新空白** session（**不 fork，不保留历史**）。旧 session 在 server 上仍存在但插件不再引用。历史记录丢失是有意权衡：fork 会复制中毒历史导致死循环。
+
+**L3 模型恢复**：`tryModelRecovery()` 接收已分类的 `PluginError & { kind: "ModelUnavailable" }`，用 `getGlobalDefaultModel()` 读 `Config.model` 做重试（每 sessionKey 最多 `MAX_RETRY_ATTEMPTS=2` 次）。注意：**继续用原 session**，不换 session——这和中毒恢复是两条独立路径。**不 re-classify**（FR-011）。
+
+**L4** per-sessionKey FIFO 串行排队，静默消息绕过队列。
+
+**L5** `expectedMessageId` 首条锁，后续不匹配事件静默丢弃。
+
+### 如何扩展错误类型
+
+1. 在 `errors.ts` 加新 kind 到 `PluginError` union
+2. 在 `errors.ts` 加对应 try* 规则函数，插入 `classify` 优先级链的正确位置
+3. 跑 `npm run typecheck`，按编译错误逐个补齐 consumer 的 matchPluginError handlers
+4. 加 `RuleName` / `FieldPath` 新成员（如需要）
+5. 更新本文件的规则优先级表
+
 ## 隐性跨文件契约
 
 以下契约不靠类型强保证，修改任一侧必须同步另一侧，否则是静默 bug：

--- a/src/handler/action-bus.ts
+++ b/src/handler/action-bus.ts
@@ -27,6 +27,20 @@ export type ProcessedAction =
   | { type: "question-requested"; sessionId: string; request: QuestionRequest }
   /** Session 进入 idle。 */
   | { type: "session-idle"; sessionId: string }
+  /**
+   * Assistant 消息元信息更新（model/cost/tokens/time）。
+   * 来源：event.ts 监听 OpenCode v2 新增的 `message.updated` 事件（携带完整 AssistantMessage 元数据）。
+   * 消费者：streaming-card 可据此在卡片中展示当前模型/费用/耗时，无需额外 HTTP 调用。
+   */
+  | {
+    type: "assistant-meta-updated"
+    sessionId: string
+    providerID?: string
+    modelID?: string
+    cost?: number
+    tokens?: Record<string, unknown>
+    time?: { created?: number; completed?: number }
+  }
 
 /** 订阅回调可以同步也可以异步。 */
 type ActionCallback = (action: ProcessedAction) => void | Promise<void>

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -16,9 +16,10 @@ import * as sender from "../feishu/sender.js"
 import {
   registerPending, unregisterPending,
   getSessionError, clearSessionError, clearRetryAttempts,
-  clearNudge, isSessionPoisoned,
+  clearNudge,
 } from "./event.js"
 import { SessionErrorDetected, extractSessionError, tryModelRecovery } from "./error-recovery.js"
+import { classify, matchPluginError, toLog } from "./errors.js"
 import { buildSessionKey, getOrCreateSession, invalidateSession } from "../session.js"
 import { registerSessionChat } from "../feishu/session-chat-map.js"
 import { extractParts, type PromptPart } from "../feishu/content-extractor.js"
@@ -435,6 +436,14 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
             handleQuestionRequested(action.request, chatId, deps.interactiveDeps, chatType, action.sessionId)
           }
           break
+        case "assistant-meta-updated":
+          // 仅记录日志；卡片 UI 未来消费模型/费用/耗时时再加分支。
+          log("info", "assistant meta 更新", {
+            sessionId: action.sessionId,
+            model: action.providerID && action.modelID ? `${action.providerID}/${action.modelID}` : undefined,
+            cost: action.cost,
+          })
+          break
       }
     })
   }
@@ -568,59 +577,81 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       return
     }
 
-    // 提取会话错误信息（来自 SessionErrorDetected 或 SSE 缓存）
+    // 提取 SSE 缓存的原始错误（如果有的话），用于 classify。
     const sessionError = extractSessionError(err, session.id)
-    let displayError = sessionError
+    const rawForClassify = sessionError?.raw ?? err
 
-    // Session 历史中毒检测优先于模型恢复：这类问题靠重试几乎不会好。
-    if (sessionError && isSessionPoisoned(sessionError.fields)) {
-      log("error", "检测到 session 历史数据中毒，创建新 session", {
-        sessionKey, oldSessionId: session.id, error: sessionError.message,
-      })
-      invalidateSession(sessionKey)
-      completeReplyRun(run.runId, "failed")
-      if (streamingCard) {
-        await streamingCard.setRunState("failed", "failed")
-      }
-      await finalizeReply({
-        streamingCard,
-        feishuClient,
-        chatId,
-        placeholderId,
-        log,
-        title: replyTitle,
-        state: "failed",
-        conclusion: "⚠️ 会话历史包含不兼容数据，已自动重置。请重新发送消息。",
-        detailsPhases: detailPhases.values(),
-      })
-      return
-    }
+    // classify 唯一调用点（FR-011）
+    const pluginError = classify(rawForClassify)
+    log("info", "error.classified", toLog(pluginError))
 
-    // 只有拿到了结构化 sessionError，才尝试做模型错误恢复。
-    if (sessionError) {
-      timedOut = false
-      const recoveryRequestMessageId = createPromptMessageId()
-      requestMessageIds.push(recoveryRequestMessageId)
-      addRunRequestMessageId(run.runId, recoveryRequestMessageId)
-      const recovery = await tryModelRecovery({
-        sessionError, sessionId: session.id, sessionKey, client, directory,
-        requestMessageId: recoveryRequestMessageId,
-        parts,
-        timeout,
-        pollInterval,
-        stablePolls,
-        query,
-        signal: mergeAbortSignals([signal, getRunAbortSignal(run.runId)]),
-        log,
-        poll,
-      })
-
-      if (recovery.recovered) {
-        const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
-        const terminalState = timedOut ? "timed_out" : "completed"
-        completeReplyRun(run.runId, terminalState)
+    await matchPluginError(pluginError, {
+      SessionPoisoned: async (e) => {
+        log("error", "检测到 session 历史数据中毒，创建新 session", {
+          sessionKey, oldSessionId: session.id, rule: e.rule,
+        })
+        invalidateSession(sessionKey)
+        completeReplyRun(run.runId, "failed")
         if (streamingCard) {
-          await streamingCard.setRunState(terminalState, terminalState)
+          await streamingCard.setRunState("failed", "failed")
+        }
+        await finalizeReply({
+          streamingCard,
+          feishuClient,
+          chatId,
+          placeholderId,
+          log,
+          title: replyTitle,
+          state: "failed",
+          conclusion: "⚠️ 会话历史包含不兼容数据，已自动重置。请重新发送消息。",
+          detailsPhases: detailPhases.values(),
+        })
+      },
+
+      ModelUnavailable: async (e) => {
+        timedOut = false
+        const recoveryRequestMessageId = createPromptMessageId()
+        requestMessageIds.push(recoveryRequestMessageId)
+        addRunRequestMessageId(run.runId, recoveryRequestMessageId)
+        const recovery = await tryModelRecovery({
+          pluginError: e, sessionId: session.id, sessionKey, client, directory,
+          requestMessageId: recoveryRequestMessageId,
+          parts,
+          timeout,
+          pollInterval,
+          stablePolls,
+          query,
+          signal: mergeAbortSignals([signal, getRunAbortSignal(run.runId)]),
+          log,
+          poll,
+        })
+
+        if (recovery.recovered) {
+          const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+          const terminalState = timedOut ? "timed_out" : "completed"
+          completeReplyRun(run.runId, terminalState)
+          if (streamingCard) {
+            await streamingCard.setRunState(terminalState, terminalState)
+          }
+          await finalizeReply({
+            streamingCard,
+            feishuClient,
+            chatId,
+            placeholderId,
+            log,
+            actualModel,
+            title: replyTitle,
+            state: terminalState,
+            conclusion: recovery.text || latestSnapshot.text || (timedOut ? "⚠️ 响应超时" : undefined),
+            detailsPhases: detailPhases.values(),
+          })
+          return
+        }
+        // 恢复失败：显示原始模型错误。
+        const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+        completeReplyRun(run.runId, "failed")
+        if (streamingCard) {
+          await streamingCard.setRunState("failed", "failed")
         }
         await finalizeReply({
           streamingCard,
@@ -630,39 +661,76 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
           log,
           actualModel,
           title: replyTitle,
-          state: terminalState,
-          conclusion: recovery.text || latestSnapshot.text || (timedOut ? "⚠️ 响应超时" : undefined),
+          state: "failed",
+          conclusion: latestSnapshot.text || ("❌ " + (sessionError?.message ?? pluginError.original)),
           detailsPhases: detailPhases.values(),
         })
-        return
-      }
-      displayError = recovery.sessionError
-    }
+      },
 
-    // 普通错误路径：把最合适的错误文案展示给用户。
-    const thrownError = err instanceof Error ? err.message : String(err)
-    const errorMessage = displayError?.message || thrownError
-    log("error", "对话处理失败", {
-      sessionId: session.id, sessionKey, chatType,
-      error: thrownError,
-      ...(displayError ? { sessionError: displayError.message } : {}),
-    })
-    const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
-    completeReplyRun(run.runId, "failed")
-    if (streamingCard) {
-      await streamingCard.setRunState("failed", "failed")
-    }
-    await finalizeReply({
-      streamingCard,
-      feishuClient,
-      chatId,
-      placeholderId,
-      log,
-      actualModel,
-      title: replyTitle,
-      state: "failed",
-      conclusion: latestSnapshot.text || ("❌ " + errorMessage),
-      detailsPhases: detailPhases.values(),
+      ContextOverflow: async (e) => {
+        log("warn", "上下文溢出", { sessionKey, providerID: e.providerID })
+        completeReplyRun(run.runId, "failed")
+        if (streamingCard) {
+          await streamingCard.setRunState("failed", "failed")
+        }
+        await finalizeReply({
+          streamingCard,
+          feishuClient,
+          chatId,
+          placeholderId,
+          log,
+          title: replyTitle,
+          state: "failed",
+          conclusion: "⚠️ 对话历史过长。请开始新对话（/new 或直接在新会话里发消息）。",
+          detailsPhases: detailPhases.values(),
+        })
+      },
+
+      Unauthorized: async (e) => {
+        log("error", "provider 认证失败", { sessionKey, providerID: e.providerID })
+        completeReplyRun(run.runId, "failed")
+        if (streamingCard) {
+          await streamingCard.setRunState("failed", "failed")
+        }
+        await finalizeReply({
+          streamingCard,
+          feishuClient,
+          chatId,
+          placeholderId,
+          log,
+          title: replyTitle,
+          state: "failed",
+          conclusion: "⚠️ 模型 provider 认证失败，请联系管理员检查 API key。",
+          detailsPhases: detailPhases.values(),
+        })
+      },
+
+      UnknownUpstream: async (e) => {
+        const thrownError = err instanceof Error ? err.message : String(err)
+        const errorMessage = sessionError?.message || thrownError
+        log("error", "对话处理失败", {
+          sessionId: session.id, sessionKey, chatType,
+          hint: e.hint,
+          error: thrownError,
+        })
+        const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+        completeReplyRun(run.runId, "failed")
+        if (streamingCard) {
+          await streamingCard.setRunState("failed", "failed")
+        }
+        await finalizeReply({
+          streamingCard,
+          feishuClient,
+          chatId,
+          placeholderId,
+          log,
+          actualModel,
+          title: replyTitle,
+          state: "failed",
+          conclusion: latestSnapshot.text || ("❌ " + errorMessage),
+          detailsPhases: detailPhases.values(),
+        })
+      },
     })
   } finally {
     done = true

--- a/src/handler/error-recovery.ts
+++ b/src/handler/error-recovery.ts
@@ -9,9 +9,10 @@ import type { LogFn } from "../types.js"
 import type { PromptPart } from "../feishu/content-extractor.js"
 import {
   getRetryAttempts, setRetryAttempts, MAX_RETRY_ATTEMPTS, clearRetryAttempts,
-  getSessionError, clearSessionError, isModelError,
+  getSessionError, clearSessionError,
   type CachedSessionError,
 } from "./event.js"
+import type { PluginError } from "./errors.js"
 
 /**
  * `pollForResponse()` 在轮询期间发现 SSE 错误时抛出的专用异常。
@@ -31,8 +32,6 @@ export interface RecoveryResult {
   readonly recovered: boolean
   /** 恢复成功时的最终文本。 */
   readonly text?: string
-  /** 恢复失败时应展示/继续处理的错误对象。 */
-  readonly sessionError?: CachedSessionError
 }
 
 /**
@@ -89,15 +88,17 @@ type PollFn = (
 /**
  * 尝试做一次模型错误恢复。
  *
+ * 调用方已通过 classify() 确认 kind === "ModelUnavailable"，
+ * 这里不再做错误识别，直接尝试切回全局默认模型重试。
+ *
  * 真正会进入重试的前提：
- * - 错误字段被识别为模型类错误
  * - 尚未超过重试上限
  * - 能读到有效的全局默认模型
  *
  * AbortError 不属于恢复失败，而是上层主动中断，因此必须继续向外抛。
  */
 export async function tryModelRecovery(params: {
-  readonly sessionError: CachedSessionError
+  readonly pluginError: PluginError & { kind: "ModelUnavailable" }
   readonly sessionId: string
   readonly sessionKey: string
   readonly client: OpencodeClient
@@ -113,27 +114,23 @@ export async function tryModelRecovery(params: {
   readonly poll: PollFn
 }): Promise<RecoveryResult> {
   const {
-    sessionError, sessionId, sessionKey, client, directory,
+    pluginError, sessionId, sessionKey, client, directory,
     requestMessageId,
     parts, timeout, pollInterval, stablePolls, query, signal,
     log, poll,
   } = params
 
-  log("info", "错误字段检查", {
+  log("info", "recovery.model.attempted", {
     sessionKey,
-    fields: sessionError.fields,
-    isModel: isModelError(sessionError.fields),
+    kind: pluginError.kind,
+    providerID: pluginError.providerID,
+    evidenceCount: pluginError.evidence.length,
   })
-
-  // 不是模型类错误时，不在这里兜底，交回上层按普通错误处理。
-  if (!isModelError(sessionError.fields)) {
-    return { recovered: false, sessionError }
-  }
 
   const attempts = getRetryAttempts(sessionKey)
   if (attempts >= MAX_RETRY_ATTEMPTS) {
     log("warn", "已达重试上限，放弃恢复", { sessionKey, attempts })
-    return { recovered: false, sessionError }
+    return { recovered: false }
   }
 
   try {
@@ -150,7 +147,7 @@ export async function tryModelRecovery(params: {
 
     if (!modelOverride) {
       log("warn", "全局默认模型未配置，放弃恢复", { sessionKey })
-      return { recovered: false, sessionError }
+      return { recovered: false }
     }
 
     // 先记一次尝试次数，防止异常路径漏记。
@@ -194,24 +191,12 @@ export async function tryModelRecovery(params: {
     }
 
     const errMsg = recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr)
-    let updatedError: CachedSessionError
-    if (recoveryErr instanceof SessionErrorDetected) {
-      // 恢复期间如果直接收到了新的结构化 SSE 错误，优先使用它。
-      updatedError = recoveryErr.sessionError
-      clearSessionError(sessionId)
-    } else {
-      // 否则再回头看看 event.ts 是否已经缓存了更准确的 session.error。
-      const sseError = getSessionError(sessionId)
-      if (sseError) {
-        updatedError = sseError
-        clearSessionError(sessionId)
-      } else {
-        updatedError = { message: errMsg, fields: [] }
-      }
-    }
+
+    // 清理可能残留的 SSE 错误缓存。
+    clearSessionError(sessionId)
 
     log("error", "模型恢复失败", { sessionId, sessionKey, error: errMsg })
 
-    return { recovered: false, sessionError: updatedError }
+    return { recovered: false }
   }
 }

--- a/src/handler/errors.ts
+++ b/src/handler/errors.ts
@@ -1,0 +1,369 @@
+/**
+ * 错误分类：typed discriminated union 替代递归 string 扫描。
+ *
+ * 所有错误经 `classify()` 转为 `PluginError`（5 kinds），
+ * consumer 通过 `matchPluginError()` exhaustive handler 消费。
+ *
+ * @see spec: specs/027-typed-error-taxonomy/spec.md
+ * @see plan: specs/027-typed-error-taxonomy/plan.md
+ */
+
+// ═══════════ 字段路径（literal union 防 drift） ═══════════
+
+export type FieldPath =
+  | "name"
+  | "data.message"
+  | "data.responseBody"
+  | "data.providerID"
+  | "data.modelId"
+  | "data.isRetryable"
+  | "data.statusCode"
+
+// ═══════════ 规则名（literal union 防 drift） ═══════════
+
+export type RuleName =
+  | "auth/provider-auth-error"
+  | "context/overflow-error"
+  | "model/provider-not-found"
+  | "model/unknown-error-with-pattern"
+  | "poison/file-part-media-type"
+  | "poison/tool-choice-type"
+  | "poison/localshell-schema"
+  | "poison/zoderror-localshell"
+
+// ═══════════ UnknownUpstream hint ═══════════
+
+export type UnknownHint =
+  | "non-error-throw"
+  | "circular-ref"
+  | "classifier-threw"
+  | "unrecognized-shape"
+
+// ═══════════ Evidence（4 种 probe via） ═══════════
+
+export type Evidence =
+  | { readonly via: "name";        readonly path: "name";          readonly value: string }
+  | { readonly via: "field";       readonly path: FieldPath;       readonly value: string }
+  | { readonly via: "pattern";     readonly path: FieldPath;       readonly pattern: string; readonly match: string }
+  | { readonly via: "http-status"; readonly status: number }
+
+// ═══════════ Base interface ═══════════
+
+export interface PluginErrorBase {
+  readonly evidence: readonly Evidence[]
+  readonly original: string
+  readonly raw: unknown
+}
+
+// ═══════════ 5 kinds discriminated union ═══════════
+
+export type PluginError =
+  | (PluginErrorBase & { readonly kind: "SessionPoisoned";  readonly rule: RuleName })
+  | (PluginErrorBase & { readonly kind: "ModelUnavailable"; readonly providerID?: string; readonly modelId?: string })
+  | (PluginErrorBase & { readonly kind: "ContextOverflow";  readonly providerID?: string })
+  | (PluginErrorBase & { readonly kind: "Unauthorized";     readonly providerID?: string })
+  | (PluginErrorBase & { readonly kind: "UnknownUpstream"; readonly hint?: UnknownHint })
+
+// ═══════════ Probe function type ═══════════
+
+export type Probe<K extends PluginError["kind"]> = (
+  raw: unknown,
+  collect: (evidence: Evidence) => void,
+) => Extract<PluginError, { kind: K }> | null
+
+// ═══════════ Utilities ═══════════
+
+/**
+ * 把任意抛出物转为 string，处理 Error / string / plain object / null /
+ * undefined / 循环引用。
+ */
+export function stringify(raw: unknown): string {
+  if (raw === null || raw === undefined) return String(raw)
+  if (typeof raw === "string") return raw
+  if (raw instanceof Error) {
+    return raw.message || raw.name || String(raw)
+  }
+  try {
+    return JSON.stringify(raw)
+  } catch {
+    return "[unserializable]"
+  }
+}
+
+/** 截断到前 n 字，超出时追加 `...`。 */
+export function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + "..." : s
+}
+
+// ═══════════ 内部工具 ═══════════
+
+/** 安全读取 raw 对象的 name 字段（SDK error discriminant）。 */
+function getErrorName(raw: unknown): string | undefined {
+  if (raw && typeof raw === "object") {
+    const name = (raw as Record<string, unknown>).name
+    return typeof name === "string" ? name : undefined
+  }
+  return undefined
+}
+
+/** 安全读取 raw.data 嵌套字段。 */
+function getDataField(raw: unknown, field: string): unknown {
+  if (raw && typeof raw === "object") {
+    const data = (raw as Record<string, unknown>).data
+    if (data && typeof data === "object") {
+      return (data as Record<string, unknown>)[field]
+    }
+  }
+  return undefined
+}
+
+/** 安全读取 raw.data 中的 string 字段。 */
+function getDataString(raw: unknown, field: string): string | undefined {
+  const v = getDataField(raw, field)
+  return typeof v === "string" ? v : undefined
+}
+
+// ═══════════ try* 规则（按优先级链排序） ═══════════
+
+/** 条件 A 白名单：Poison 规则允许的 error.name 集合。 */
+const POISON_NAME_WHITELIST = new Set([
+  "StructuredOutputError",
+  "UnknownError",
+  "APIError",
+])
+
+/** 条件 B 子串模式。 */
+const POISON_SUBSTRING_PATTERNS: ReadonlyArray<{ pattern: string; rule: RuleName }> = [
+  { pattern: "file part media type", rule: "poison/file-part-media-type" },
+  { pattern: "tool choice type",     rule: "poison/tool-choice-type" },
+]
+
+/** 条件 B 正则模式。 */
+const POISON_REGEX_PATTERNS: ReadonlyArray<{ pattern: RegExp; rule: RuleName }> = [
+  { pattern: /localshell.*schema/i,       rule: "poison/localshell-schema" },
+  { pattern: /zoderror.*local.?shell/i,   rule: "poison/zoderror-localshell" },
+]
+
+/** 模型不可用的 pattern 匹配（用于 UnknownError 降级路径）。 */
+const MODEL_PATTERNS = [
+  /model\s+not\s+found/i,
+  /model\b.*\bnot\s+(found|supported|available)/i,
+  /model\s+is\s+not\s+(available|supported)/i,
+  /modelnotfound/i,
+  /model_not_found/i,
+]
+
+const tryUnauthorized: Probe<"Unauthorized"> = (raw, collect) => {
+  if (getErrorName(raw) !== "ProviderAuthError") return null
+  collect({ via: "name", path: "name", value: "ProviderAuthError" })
+  return {
+    kind: "Unauthorized",
+    providerID: getDataString(raw, "providerID"),
+    evidence: [],
+    original: truncate(stringify(raw), 500),
+    raw,
+  } as Extract<PluginError, { kind: "Unauthorized" }>
+}
+
+const tryContextOverflow: Probe<"ContextOverflow"> = (raw, collect) => {
+  if (getErrorName(raw) !== "ContextOverflowError") return null
+  collect({ via: "name", path: "name", value: "ContextOverflowError" })
+  return {
+    kind: "ContextOverflow",
+    providerID: getDataString(raw, "providerID"),
+    evidence: [],
+    original: truncate(stringify(raw), 500),
+    raw,
+  } as Extract<PluginError, { kind: "ContextOverflow" }>
+}
+
+const tryModelUnavailable: Probe<"ModelUnavailable"> = (raw, collect) => {
+  const name = getErrorName(raw)
+
+  // 路径 1：精确 name 匹配
+  if (name === "ProviderModelNotFoundError") {
+    collect({ via: "name", path: "name", value: "ProviderModelNotFoundError" })
+    return {
+      kind: "ModelUnavailable",
+      providerID: getDataString(raw, "providerID"),
+      modelId: getDataString(raw, "modelId"),
+      evidence: [],
+      original: truncate(stringify(raw), 500),
+      raw,
+    } as Extract<PluginError, { kind: "ModelUnavailable" }>
+  }
+
+  // 路径 2：UnknownError + data.message pattern
+  if (name === "UnknownError") {
+    const msg = getDataString(raw, "message") ?? ""
+    for (const pat of MODEL_PATTERNS) {
+      const m = msg.match(pat)
+      if (m) {
+        collect({ via: "pattern", path: "data.message", pattern: pat.source, match: m[0] })
+        return {
+          kind: "ModelUnavailable",
+          providerID: getDataString(raw, "providerID"),
+          modelId: getDataString(raw, "modelId"),
+          evidence: [],
+          original: truncate(stringify(raw), 500),
+          raw,
+        } as Extract<PluginError, { kind: "ModelUnavailable" }>
+      }
+    }
+  }
+
+  return null
+}
+
+const trySessionPoisoned: Probe<"SessionPoisoned"> = (raw, collect) => {
+  // 条件 A：error.name 白名单
+  const name = getErrorName(raw)
+  if (!name || !POISON_NAME_WHITELIST.has(name)) return null
+
+  // 条件 B：data.message 匹配 poison pattern
+  const msg = getDataString(raw, "message") ?? ""
+
+  // 子串模式
+  for (const entry of POISON_SUBSTRING_PATTERNS) {
+    if (msg.toLowerCase().includes(entry.pattern)) {
+      collect({ via: "pattern", path: "data.message", pattern: entry.pattern, match: msg.slice(0, 200) })
+      // 再收集 name evidence
+      collect({ via: "name", path: "name", value: name })
+      return {
+        kind: "SessionPoisoned",
+        rule: entry.rule,
+        evidence: [],
+        original: truncate(stringify(raw), 500),
+        raw,
+      } as Extract<PluginError, { kind: "SessionPoisoned" }>
+    }
+  }
+
+  // 正则模式
+  for (const entry of POISON_REGEX_PATTERNS) {
+    const m = msg.match(entry.pattern)
+    if (m) {
+      collect({ via: "pattern", path: "data.message", pattern: entry.pattern.source, match: m[0] })
+      collect({ via: "name", path: "name", value: name })
+      return {
+        kind: "SessionPoisoned",
+        rule: entry.rule,
+        evidence: [],
+        original: truncate(stringify(raw), 500),
+        raw,
+      } as Extract<PluginError, { kind: "SessionPoisoned" }>
+    }
+  }
+
+  return null
+}
+
+// ═══════════ classify（规则优先级链） ═══════════
+
+/**
+ * 把任意抛出物转为 PluginError。
+ * 优先级：Auth → Context → Model → Poison → fallback。
+ * 内层 try/catch 兜底，classify 永不 throw（FR-009）。
+ */
+export function classify(raw: unknown): PluginError {
+  try {
+    const original = truncate(stringify(raw), 500)
+    const evidence: Evidence[] = []
+
+    const collect = (e: Evidence) => { evidence.push(e) }
+
+    // 优先级 1：Auth（强证据，精确 name 匹配）
+    const auth = tryUnauthorized(raw, collect)
+    if (auth) return { ...auth, evidence, original }
+
+    // 优先级 2：ContextOverflow（强证据）
+    const ctx = tryContextOverflow(raw, collect)
+    if (ctx) return { ...ctx, evidence, original }
+
+    // 优先级 3：Model（中等证据）
+    const model = tryModelUnavailable(raw, collect)
+    if (model) return { ...model, evidence, original }
+
+    // 优先级 4：Poison（弱证据，two-factor，放最后）
+    const poison = trySessionPoisoned(raw, collect)
+    if (poison) return { ...poison, evidence, original }
+
+    // fallback
+    return {
+      kind: "UnknownUpstream",
+      hint: "unrecognized-shape",
+      evidence: [],
+      original,
+      raw,
+    }
+  } catch {
+    // classify 自身不应 throw（FR-009）
+    return {
+      kind: "UnknownUpstream",
+      hint: "classifier-threw",
+      evidence: [],
+      original: "[classify threw]",
+      raw,
+    }
+  }
+}
+
+// ═══════════ matchPluginError（exhaustive matcher） ═══════════
+
+/**
+ * 替代 switch(err.kind)，强制消费者覆盖所有 PluginError kind。
+ * 漏任何 kind 的 handler → TypeScript 编译报错。
+ */
+export function matchPluginError<R>(
+  err: PluginError,
+  handlers: { [K in PluginError["kind"]]: (e: Extract<PluginError, { kind: K }>) => R },
+): R {
+  return handlers[err.kind](err as Extract<PluginError, typeof err.kind>)
+}
+
+// ═══════════ toLog（安全日志 payload） ═══════════
+
+/**
+ * 从 PluginError 生成安全的 log payload。
+ * 不暴露 raw（防 secrets 泄漏）。
+ */
+export function toLog(err: PluginError): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    kind: err.kind,
+    evidenceCount: err.evidence.length,
+    evidencePrimary: err.evidence[0]
+      ? { via: err.evidence[0].via, path: "path" in err.evidence[0] ? err.evidence[0].path : undefined }
+      : undefined,
+  }
+
+  if (err.kind === "SessionPoisoned") {
+    base.rule = err.rule
+  }
+  if (err.kind === "ModelUnavailable" || err.kind === "ContextOverflow" || err.kind === "Unauthorized") {
+    if (err.providerID) base.providerID = err.providerID
+  }
+  if (err.kind === "ModelUnavailable" && err.modelId) {
+    base.modelId = err.modelId
+  }
+  if (err.kind === "UnknownUpstream" && err.hint) {
+    base.hint = err.hint
+  }
+
+  return base
+}
+
+// ═══════════ PluginErrorThrown（nominal wrapper） ═══════════
+
+/**
+ * 仅在需要跨 throw/catch 边界传播 PluginError identity 时使用。
+ * 一般场景用 union + matchPluginError 即可。
+ */
+export class PluginErrorThrown extends Error {
+  readonly inner: PluginError
+
+  constructor(inner: PluginError) {
+    super(`[${inner.kind}] ${truncate(inner.original, 200)}`)
+    this.inner = inner
+    this.name = "PluginErrorThrown"
+  }
+}

--- a/src/handler/event.ts
+++ b/src/handler/event.ts
@@ -6,7 +6,34 @@
  * 2. 维护若干与 session 绑定的短期状态缓存
  * 3. 把事件转成 action-bus 广播给流式卡片、交互卡片等消费者
  */
-import type { Event } from "@opencode-ai/sdk"
+import type { Event as SdkEvent } from "@opencode-ai/sdk"
+
+/**
+ * 扩展的事件类型，覆盖 v2 SDK 新增的事件。
+ *
+ * v1 SDK 的 Event 联合类型不含 `message.part.delta`、`permission.asked`、
+ * `question.asked` 等 v2 事件。插件 event hook 实际会收到这些事件，
+ * 此处用本地类型补充，避免 `as any` 强制类型断言。
+ */
+type Event = SdkEvent | {
+  type: "message.part.delta"
+  properties: { sessionID: string; messageID: string; partID: string; field: string; delta: string }
+} | {
+  type: "permission.asked"
+  properties: Record<string, unknown>
+} | {
+  type: "question.asked"
+  properties: Record<string, unknown>
+} | {
+  type: "message.updated"
+  properties: { info: { role?: string; id?: string; sessionID?: string; providerID?: string; modelID?: string; cost?: number; tokens?: Record<string, unknown>; time?: { created?: number; completed?: number }; [key: string]: unknown } }
+} | {
+  type: "todo.updated"
+  properties: { sessionID: string; todos: Array<{ id: string; content: string; status: string; priority: string }> }
+} | {
+  type: string
+  properties?: Record<string, unknown>
+}
 
 import * as sender from "../feishu/sender.js"
 import type { LogFn, PermissionRequest, QuestionRequest } from "../types.js"
@@ -48,7 +75,7 @@ const pendingBySession = new Map<string, PendingReplyPayload>()
 /** 缓存的会话错误信息 */
 export interface CachedSessionError {
   message: string    // 用于展示的错误消息
-  fields: string[]   // 所有提取的错误文本字段（用于模式匹配）
+  raw?: unknown      // 原始错误对象，供 classify() 使用
 }
 
 /** SSE 侧上报的会话错误，保留 30 秒供 chat.ts 轮询路径消费。 */
@@ -106,105 +133,6 @@ export function unregisterPending(sessionId: string): void {
 }
 
 /**
- * 从 error 对象提取所有可用于模式匹配的文本字段。
- *
- * 策略：显式提取 message/type/name（可能是不可枚举属性）+
- * Object.values 提取所有可枚举 string 值 + data.message 嵌套字段。
- * 原生 Error 的 message/name 是不可枚举的，Object.values 无法获取，
- * 因此必须显式提取。最终用 Set 去重。
- */
-export function extractErrorFields(error: unknown): string[] {
-  if (typeof error === "string") return [error]
-  if (error && typeof error === "object") {
-    const fields: string[] = []
-    collectStrings(error, fields, 3)
-    return [...new Set(fields)]
-  }
-  return [String(error)]
-}
-
-/**
- * 递归提取对象中所有 string 值（最大深度限制防止循环引用）。
- * 同时显式提取 message/type/name（可能不可枚举）。
- */
-function collectStrings(obj: unknown, out: string[], maxDepth: number): void {
-  if (maxDepth <= 0 || !obj || typeof obj !== "object") return
-  const e = obj as Record<string, unknown>
-  // 显式提取可能不可枚举的标准 Error 属性
-  for (const key of ["message", "type", "name"]) {
-    const v = e[key]
-    if (typeof v === "string" && v.length > 0) out.push(v)
-  }
-  // 提取所有可枚举值：string 直接收集，object 递归下探
-  for (const v of Object.values(e)) {
-    if (typeof v === "string" && v.length > 0) out.push(v)
-    else if (Array.isArray(v)) { for (const item of v) collectStrings(item, out, maxDepth - 1) }
-    else if (v && typeof v === "object") collectStrings(v, out, maxDepth - 1)
-  }
-}
-
-/**
- * 检测 session 历史数据中毒（每次 LLM 调用都会重复触发的错误）。
- */
-/**
- * session 历史中毒的高危关键词。
- *
- * 这类错误通常意味着历史消息里存在当前模型无法接受的 part/schema，
- * 单纯重试不会好，必须让上层主动丢弃旧 session。
- */
-const SESSION_POISON_PATTERNS = [
-  "file part media type",
-  "tool choice type",
-]
-
-/**
- * 某些“中毒”错误只会以格式化后的校验异常出现。
- *
- * 这些模式不是稳定子串，而是会夹杂字段名、空格或格式化差异，
- * 因此单独收敛成正则常量，避免散落在判断逻辑里。
- */
-const SESSION_POISON_REGEX_PATTERNS = [
-  /localshell.*schema/,
-  /zoderror.*local.?shell/,
-]
-
-/**
- * 检测错误字段是否指向“session 历史已经中毒”。
- *
- * 一旦命中，上层会直接 `invalidateSession()` 而不是再尝试模型恢复。
- */
-export function isSessionPoisoned(fields: string[]): boolean {
-  return fields.some(f => {
-    const l = f.toLowerCase()
-    if (SESSION_POISON_PATTERNS.some(p => l.includes(p))) return true
-    return SESSION_POISON_REGEX_PATTERNS.some(pattern => pattern.test(l))
-  })
-}
-
-/**
- * 检测错误字段是否包含模型不兼容错误。
- *
- * 双层匹配策略防止再犯：
- * 1. 精确子串：覆盖已知的错误码和格式化字符串
- * 2. 关键词组合：检测 "model" + 否定/不可用语义词，覆盖未知的自然语言变体
- */
-export function isModelError(fields: string[]): boolean {
-  const exactPatterns = [
-    "model not found", "modelnotfound", "model_not_found",
-    "model not supported", "model_not_supported", "model is not supported",
-  ]
-  const negativeWords = ["not", "unsupported", "invalid", "unavailable", "unknown", "does not", "doesn't", "cannot", "不支持", "不存在", "无效"]
-  return fields.some(f => {
-    const l = f.toLowerCase()
-    // 层 1：精确子串匹配（已知模式）
-    if (exactPatterns.some(p => l.includes(p))) return true
-    // 层 2：关键词组合匹配（"model" + 否定词 = 模型不可用）
-    if (l.includes("model") && negativeWords.some(w => l.includes(w))) return true
-    return false
-  })
-}
-
-/**
  * 事件主分发入口。
  *
  * 这里先按最关键的几个大类做路由：
@@ -216,7 +144,7 @@ export async function handleEvent(
   event: Event,
   deps: EventDeps,
 ): Promise<void> {
-  switch (event.type as string) {
+  switch (event.type) {
     case "message.part.delta": {
       const props = (event as any).properties as {
         sessionID?: string
@@ -266,6 +194,28 @@ export async function handleEvent(
     case "session.error":
       handleSessionErrorEvent(event, deps)
       break
+    // message.updated：v2 SDK 新增事件，携带完整 AssistantMessage 元数据（model/cost/tokens/time）
+    // 仅处理 role=assistant 的情况；同一 assistant message 可能触发多次（部分完成→完全完成），消费者需具备幂等性
+    case "message.updated": {
+      const info = (event.properties as any)?.info as { role?: string; sessionID?: string; providerID?: string; modelID?: string; cost?: number; tokens?: Record<string, unknown>; time?: { created?: number; completed?: number } } | undefined
+      if (info?.role === "assistant" && info.sessionID) {
+        const payload = pendingBySession.get(info.sessionID)
+        if (payload) {
+          payload.hasActivity = true
+          // 通过 action-bus 广播 assistant-meta-updated；消费者（streaming-card）据此展示模型/费用/耗时
+          emit(info.sessionID, {
+            type: "assistant-meta-updated",
+            sessionId: info.sessionID,
+            providerID: info.providerID,
+            modelID: info.modelID,
+            cost: info.cost,
+            tokens: info.tokens,
+            time: info.time,
+          }, deps.log)
+        }
+      }
+      break
+    }
     default:
       handleV2Event(event, deps)
       break
@@ -394,11 +344,22 @@ function handleSessionErrorEvent(event: Event, deps: EventDeps): void {
     errMsg = String(error)
   }
 
-  const fields = extractErrorFields(error)
-
   deps.log("warn", "收到 session.error 事件", { sessionId, errMsg })
 
-  sessionErrors.set(sessionId, { message: errMsg, fields })
+  // Phase 0 临时采样日志：记录完整 error 形状，为主 PR 的回归 fixtures 提供真实样本。
+  // 此日志在 027 主 PR 合入后删除（T035）。
+  const e = error as Record<string, unknown> | undefined
+  deps.log("warn", "session.error.raw-shape", {
+    errorName: (e as { name?: string })?.name,
+    errorKeys: e && typeof e === "object" ? Object.keys(e) : [],
+    dataKeys: (e as { data?: Record<string, unknown> })?.data && typeof (e as { data?: Record<string, unknown> }).data === "object"
+      ? Object.keys((e as { data: Record<string, unknown> }).data)
+      : [],
+    dataMessage: ((e as { data?: { message?: string } })?.data?.message ?? "").slice(0, 500),
+    sessionId,
+  })
+
+  sessionErrors.set(sessionId, { message: errMsg, raw: error })
 
   // 不在此处做 fork 恢复或向用户发送错误——统一由 chat.ts catch 块处理
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import { initDedup } from "./feishu/dedup.js"                                   
 import { createSendCardTool } from "./tools/send-card.js"                          // Agent 可调用的 feishu_send_card tool 工厂
 import { getChatIdBySession } from "./feishu/session-chat-map.js"                  // 会话 → 聊天 ID 映射查询（判断是否飞书会话）
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client"                  // OpenCode v2 REST 客户端（用于权限/问答交互回复）
+import { TtlMap } from "./utils/ttl-map.js" // 引入已有的 TtlMap：60s 缓存 config.get() 结果，消除 system.transform 每次触发都调 HTTP 的开销
 
 /** 日志服务标识，所有 client.app.log() 调用都携带此名称 */
 const SERVICE_NAME = "opencode-feishu"
@@ -90,6 +91,10 @@ export const FeishuPlugin: Plugin = async (ctx) => {
   const { client } = ctx
   // `gateway` 用于在各个 hook 闭包里判断网关是否已经成功初始化。
   let gateway: FeishuGatewayResult | null = null
+
+  // 60s 缓存 config.get() 结果（model 只在用户手动切换模型时才变化，缓存基本等价于实时）
+  const configCache = new TtlMap<{ model?: string }>(60_000)
+  const CONFIG_CACHE_KEY = "global"
 
   // 统一日志桥接：始终写入 OpenCode 日志；调试模式额外输出 stderr JSON。
   const log: LogFn = (level, message, extra) => {
@@ -204,13 +209,60 @@ export const FeishuPlugin: Plugin = async (ctx) => {
       // 注入运行时上下文（工作目录 + 当前模型）
       const runtimeLines = [`当前工作目录: ${resolvedConfig.directory || ctx.directory || "未设置"}`]
       try {
-        const cfg = await client.config.get({ query: { directory: resolvedConfig.directory || undefined } })
-        if (cfg?.data?.model) runtimeLines.push(`当前模型: ${cfg.data.model}`)
+        // 先查缓存；缓存命中则跳过 HTTP 调用（60s 内有效）
+        let cached = configCache.get(CONFIG_CACHE_KEY)
+        if (!cached) {
+          // 缓存未命中，调一次 HTTP 并写入缓存
+          const cfg = await client.config.get({ query: { directory: resolvedConfig.directory || undefined } })
+          cached = { model: cfg?.data?.model }
+          configCache.set(CONFIG_CACHE_KEY, cached)
+        }
+        if (cached.model) runtimeLines.push(`当前模型: ${cached.model}`)
       } catch (err) {
         log("warn", "获取 config 失败", { error: err instanceof Error ? err.message : String(err) })
       }
       // 作为独立 system 段落注入，避免和 skill 文本粘连。
       output.system.push(runtimeLines.join("\n"))
+    },
+
+    // chat.message：每条消息进入 agent 前记录结构化日志（sessionId/agent/model），便于飞书侧排查问题
+    // 仅在飞书会话中生效；非飞书渠道直接 return 不影响其他插件
+    "chat.message": async (input, _output) => {
+      if (!gateway) return
+      const { sessionID, agent, model } = input
+      if (!sessionID || !getChatIdBySession(sessionID)) return
+      log("info", "chat.message 到达", {
+        sessionId: sessionID,
+        agent: agent ?? "default",
+        model: model ? `${model.providerID}/${model.modelID}` : "unknown",
+      })
+    },
+
+    // permission.ask：飞书会话中自动放行 read 权限（用户已通过飞书认证，读文件风险低）
+    // write/execute 等高危权限保持默认 ask 行为，交互卡片正常弹出
+    // input 类型为 Plugin SDK Permission，不含 sessionID，通过 as any 安全提取（SDK 类型定义限制）
+    "permission.ask": async (input, output) => {
+      if (!gateway) return
+      const sessionID = (input as any).sessionID as string | undefined
+      if (!sessionID || !getChatIdBySession(sessionID)) return
+      const permission = (input as any).permission as string | undefined
+      if (permission === "read") {
+        output.status = "allow"
+        log("info", "飞书会话自动授权 read 权限", { sessionId: sessionID })
+      }
+    },
+
+    // tool.execute.after：工具执行完成后记录日志（tool 名/sessionId/callID），飞书侧可据此排查工具调用问题
+    // 仅在飞书会话中生效；其他渠道早期 return
+    "tool.execute.after": async (input, _output) => {
+      if (!gateway) return
+      const { tool, sessionID } = input
+      if (!sessionID || !getChatIdBySession(sessionID)) return
+      log("info", "工具执行完成", {
+        tool,
+        sessionId: sessionID,
+        callID: input.callID,
+      })
     },
   }
   return hooks

--- a/src/tools/CLAUDE.md
+++ b/src/tools/CLAUDE.md
@@ -18,3 +18,12 @@
 
 - 工具要保持幂等或可预期，不用隐藏副作用。
 - 参数含义必须与实际行为严格对应，不能靠 prompt 猜。
+
+## 文件职责
+
+### send-card.ts
+
+- `createSendCardTool(deps)` — 注册 `feishu_send_card` 工具定义，包含 22 种 Card 2.0 组件的 Zod schema 和调用适配。
+- `buildCardFromDSL(args, chatId, chatType)` — 统一 DSL → CardKit 2.0 JSON 翻译，同时被 agent tool 和权限/问答交互卡片复用。
+- `ButtonInput.actionPayload` — 内部字段，有此字段时直接用作按钮 value（权限/问答场景），无时构造 send_message action；不暴露给 agent Zod schema。
+- `SectionInput` — 支持 22 种区块类型：markdown/divider/note/actions（基础）、image/person/chart/table（展示）、input/select/date_picker/collapse 等（交互）。

--- a/src/utils/CLAUDE.md
+++ b/src/utils/CLAUDE.md
@@ -17,3 +17,9 @@
 ## 修改约束
 
 - 优先保持无副作用、易测试、依赖最少。
+
+## 文件职责
+
+- `ttl-map.ts` — 带 TTL 自动过期的轻量缓存容器，采用"每个 key 一个 timer"模型，到期条目由 `setTimeout` 主动清除。
+- 泛型 `TtlMap<V>` 支持 `get`/`set`/`has`/`delete` 四个操作，`set` 可传入自定义 TTL 覆盖构造时的默认值。
+- 项目内多处复用：会话缓存（`session.ts`）、中毒会话黑名单（`error-recovery.ts`）、消息去重窗口（`dedup.ts`）等。

--- a/tests/handler/errors.test.ts
+++ b/tests/handler/errors.test.ts
@@ -1,0 +1,245 @@
+/**
+ * errors.ts 单元测试。
+ *
+ * 使用 Node 内置 test runner（node --test）。
+ * 运行：npx tsx --test tests/handler/errors.test.ts
+ */
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import {
+  classify,
+  matchPluginError,
+  toLog,
+  stringify,
+  truncate,
+  PluginErrorThrown,
+  type PluginError,
+} from "../../src/handler/errors.js"
+
+import realSamples from "./fixtures/real-samples.json" with { type: "json" }
+import trapSamples from "./fixtures/trap-samples.json" with { type: "json" }
+
+// ═══════════ Utilities ═══════════
+
+describe("stringify", () => {
+  it("handles null", () => assert.equal(stringify(null), "null"))
+  it("handles undefined", () => assert.equal(stringify(undefined), "undefined"))
+  it("handles string", () => assert.equal(stringify("hello"), "hello"))
+  it("handles Error", () => assert.equal(stringify(new Error("boom")), "boom"))
+  it("handles Error with only name", () => {
+    const e = new Error()
+    e.name = "CustomError"
+    assert.equal(stringify(e), "CustomError")
+  })
+  it("handles plain object", () => assert.equal(stringify({ a: 1 }), '{"a":1}'))
+  it("handles number", () => assert.equal(stringify(42), "42"))
+  it("handles circular ref", () => {
+    const obj: Record<string, unknown> = {}
+    obj.self = obj
+    assert.equal(stringify(obj), "[unserializable]")
+  })
+})
+
+describe("truncate", () => {
+  it("short string unchanged", () => assert.equal(truncate("abc", 5), "abc"))
+  it("exact length unchanged", () => assert.equal(truncate("abcde", 5), "abcde"))
+  it("long string truncated", () => assert.equal(truncate("abcdef", 5), "abcde..."))
+  it("empty string", () => assert.equal(truncate("", 5), ""))
+})
+
+// ═══════════ classify — real samples ═══════════
+
+describe("classify (real samples)", () => {
+  for (const sample of realSamples) {
+    it(`${sample.id}: ${sample.expectedKind}`, () => {
+      const result = classify(sample.raw)
+      assert.equal(result.kind, sample.expectedKind, `Expected ${sample.expectedKind} but got ${result.kind} for ${sample.id}`)
+    })
+  }
+})
+
+// ═══════════ classify — trap samples ═══════════
+
+describe("classify (trap samples — should NOT be SessionPoisoned)", () => {
+  for (const sample of trapSamples) {
+    it(`${sample.id}: expect ${sample.expectedKind}`, () => {
+      const result = classify(sample.raw)
+      assert.equal(result.kind, sample.expectedKind,
+        `Trap ${sample.id}: expected ${sample.expectedKind} but got ${result.kind}`)
+      // 额外断言：绝不应该是 SessionPoisoned（除非 expectedKind 就是）
+      if (sample.expectedKind !== "SessionPoisoned") {
+        assert.notEqual(result.kind, "SessionPoisoned",
+          `Trap ${sample.id}: should NOT be SessionPoisoned`)
+      }
+    })
+  }
+})
+
+// ═══════════ classify — edge cases ═══════════
+
+describe("classify (edge cases)", () => {
+  it("null → UnknownUpstream", () => {
+    assert.equal(classify(null).kind, "UnknownUpstream")
+  })
+  it("undefined → UnknownUpstream", () => {
+    assert.equal(classify(undefined).kind, "UnknownUpstream")
+  })
+  it("number → UnknownUpstream", () => {
+    assert.equal(classify(42).kind, "UnknownUpstream")
+  })
+  it("empty string → UnknownUpstream", () => {
+    assert.equal(classify("").kind, "UnknownUpstream")
+  })
+  it("empty object → UnknownUpstream", () => {
+    assert.equal(classify({}).kind, "UnknownUpstream")
+  })
+  it("Error with no name/message → UnknownUpstream", () => {
+    assert.equal(classify(new Error()).kind, "UnknownUpstream")
+  })
+  it("circular ref → UnknownUpstream (no throw)", () => {
+    const obj: Record<string, unknown> = {}
+    obj.self = obj
+    const result = classify(obj)
+    assert.equal(result.kind, "UnknownUpstream")
+  })
+  it("classify never throws", () => {
+    // 传入各种可能触发异常的输入
+    const inputs = [null, undefined, 0, false, "", Symbol("test"), BigInt(1)]
+    for (const input of inputs) {
+      const result = classify(input)
+      assert.ok(result.kind, `classify(${String(input)}) should return a valid PluginError`)
+    }
+  })
+})
+
+// ═══════════ classify — evidence completeness ═══════════
+
+describe("classify (evidence completeness)", () => {
+  it("Unauthorized has ≥1 evidence", () => {
+    const err = classify({ name: "ProviderAuthError", data: { providerID: "x", message: "auth failed" } })
+    assert.ok(err.evidence.length >= 1)
+    assert.equal(err.evidence[0].via, "name")
+  })
+  it("ContextOverflow has ≥1 evidence", () => {
+    const err = classify({ name: "ContextOverflowError", data: { message: "too long" } })
+    assert.ok(err.evidence.length >= 1)
+  })
+  it("ModelUnavailable (exact name) has ≥1 evidence", () => {
+    const err = classify({ name: "ProviderModelNotFoundError", data: { providerID: "x", modelID: "y" } })
+    assert.ok(err.evidence.length >= 1)
+    assert.equal(err.evidence[0].via, "name")
+  })
+  it("ModelUnavailable (pattern) has ≥1 evidence", () => {
+    const err = classify({ name: "UnknownError", data: { message: "model not found" } })
+    assert.ok(err.evidence.length >= 1)
+    assert.equal(err.evidence[0].via, "pattern")
+  })
+  it("SessionPoisoned has ≥2 evidence (name + pattern)", () => {
+    const err = classify({ name: "StructuredOutputError", data: { message: "file part media type text/x-yaml" } })
+    assert.ok(err.evidence.length >= 2, `Expected ≥2 evidence, got ${err.evidence.length}`)
+  })
+  it("UnknownUpstream has 0 evidence", () => {
+    const err = classify({ name: "UnknownError", data: { message: "random error" } })
+    assert.equal(err.evidence.length, 0)
+  })
+})
+
+// ═══════════ classify — priority chain ═══════════
+
+describe("classify (priority chain)", () => {
+  it("Auth beats Model (ProviderAuthError wins over model pattern in message)", () => {
+    const err = classify({ name: "ProviderAuthError", data: { message: "model not found in provider" } })
+    assert.equal(err.kind, "Unauthorized")
+  })
+  it("Auth beats Poison (ProviderAuthError wins over poison pattern in message)", () => {
+    const err = classify({ name: "ProviderAuthError", data: { message: "file part media type unsupported" } })
+    assert.equal(err.kind, "Unauthorized")
+  })
+  it("Context beats Model", () => {
+    const err = classify({ name: "ContextOverflowError", data: { message: "model not found context overflow" } })
+    assert.equal(err.kind, "ContextOverflow")
+  })
+  it("Model beats Poison (model pattern checked before poison)", () => {
+    const err = classify({ name: "UnknownError", data: { message: "model not found: file part media type" } })
+    assert.equal(err.kind, "ModelUnavailable")
+  })
+  it("Poison requires two-factor (name whitelist + pattern)", () => {
+    // UnknownError name is in whitelist, but message has no poison pattern
+    const err = classify({ name: "UnknownError", data: { message: "random error" } })
+    assert.equal(err.kind, "UnknownUpstream")
+  })
+  it("Poison two-factor: name not in whitelist → not poison", () => {
+    // MessageOutputLengthError is NOT in whitelist
+    const err = classify({ name: "MessageOutputLengthError", data: { message: "file part media type" } })
+    assert.notEqual(err.kind, "SessionPoisoned")
+  })
+})
+
+// ═══════════ classify — toLog safety ═══════════
+
+describe("toLog", () => {
+  it("does not expose raw", () => {
+    const err = classify({ name: "ProviderAuthError", data: { providerID: "x", message: "secret-key-12345" } })
+    const logPayload = toLog(err)
+    const serialized = JSON.stringify(logPayload)
+    assert.ok(!serialized.includes("secret-key-12345"), "toLog should not expose raw error content")
+    assert.ok(!serialized.includes("raw"), "toLog should not include raw field")
+  })
+  it("includes kind", () => {
+    const err = classify({ name: "ProviderAuthError", data: { providerID: "x", message: "auth" } })
+    assert.equal(toLog(err).kind, "Unauthorized")
+  })
+  it("includes rule for SessionPoisoned", () => {
+    const err = classify({ name: "StructuredOutputError", data: { message: "file part media type" } })
+    assert.ok(toLog(err).rule)
+  })
+  it("includes hint for UnknownUpstream", () => {
+    const err = classify(null)
+    assert.ok(toLog(err).hint)
+  })
+})
+
+// ═══════════ matchPluginError — exhaustive ═══════════
+
+describe("matchPluginError", () => {
+  it("calls correct handler for each kind", () => {
+    const kinds: PluginError["kind"][] = [
+      "SessionPoisoned", "ModelUnavailable", "ContextOverflow", "Unauthorized", "UnknownUpstream",
+    ]
+    for (const kind of kinds) {
+      const err = classify(
+        kind === "Unauthorized" ? { name: "ProviderAuthError", data: { providerID: "x", message: "auth" } } :
+        kind === "ContextOverflow" ? { name: "ContextOverflowError", data: { message: "overflow" } } :
+        kind === "ModelUnavailable" ? { name: "ProviderModelNotFoundError", data: { providerID: "x", modelID: "y" } } :
+        kind === "SessionPoisoned" ? { name: "StructuredOutputError", data: { message: "file part media type" } } :
+        null
+      )
+      assert.equal(err.kind, kind, `classify should produce ${kind}`)
+      const result = matchPluginError(err, {
+        SessionPoisoned: () => "poison",
+        ModelUnavailable: () => "model",
+        ContextOverflow: () => "context",
+        Unauthorized: () => "auth",
+        UnknownUpstream: () => "unknown",
+      })
+      const expected =
+        kind === "SessionPoisoned" ? "poison" :
+        kind === "ModelUnavailable" ? "model" :
+        kind === "ContextOverflow" ? "context" :
+        kind === "Unauthorized" ? "auth" : "unknown"
+      assert.equal(result, expected)
+    }
+  })
+})
+
+// ═══════════ PluginErrorThrown ═══════════
+
+describe("PluginErrorThrown", () => {
+  it("wraps PluginError", () => {
+    const inner = classify({ name: "ProviderAuthError", data: { providerID: "x", message: "auth" } })
+    const thrown = new PluginErrorThrown(inner)
+    assert.equal(thrown.name, "PluginErrorThrown")
+    assert.equal(thrown.inner.kind, "Unauthorized")
+    assert.ok(thrown.message.includes("Unauthorized"))
+  })
+})

--- a/tests/handler/fixtures/real-samples.json
+++ b/tests/handler/fixtures/real-samples.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "auth-001",
+    "raw": { "name": "ProviderAuthError", "data": { "providerID": "anthropic", "message": "OAuth token has expired" } },
+    "expectedKind": "Unauthorized",
+    "expectedUserMessage": "认证失败"
+  },
+  {
+    "id": "auth-002",
+    "raw": { "name": "ProviderAuthError", "data": { "providerID": "openai", "message": "Invalid API key provided" } },
+    "expectedKind": "Unauthorized",
+    "expectedUserMessage": "认证失败"
+  },
+  {
+    "id": "auth-003",
+    "raw": { "name": "ProviderAuthError", "data": { "providerID": "google", "message": "Permission denied: API key not enabled for this model" } },
+    "expectedKind": "Unauthorized",
+    "expectedUserMessage": "认证失败"
+  },
+  {
+    "id": "context-001",
+    "raw": { "name": "ContextOverflowError", "data": { "message": "context_length_exceeded" } },
+    "expectedKind": "ContextOverflow",
+    "expectedUserMessage": "对话历史过长"
+  },
+  {
+    "id": "context-002",
+    "raw": { "name": "ContextOverflowError", "data": { "message": "Conversation history too large to compact - exceeds model context limit" } },
+    "expectedKind": "ContextOverflow",
+    "expectedUserMessage": "对话历史过长"
+  },
+  {
+    "id": "context-003",
+    "raw": { "name": "ContextOverflowError", "data": { "message": "Maximum context length exceeded", "responseBody": "{\"error\":\"context_length_exceeded\"}" } },
+    "expectedKind": "ContextOverflow",
+    "expectedUserMessage": "对话历史过长"
+  },
+  {
+    "id": "model-001",
+    "raw": { "name": "ProviderModelNotFoundError", "data": { "providerID": "anthropic", "modelID": "claude-3-opus", "message": "Model not found" } },
+    "expectedKind": "ModelUnavailable",
+    "expectedUserMessage": "模型不可用"
+  },
+  {
+    "id": "model-002",
+    "raw": { "name": "ProviderModelNotFoundError", "data": { "providerID": "openai", "modelID": "gpt-5", "suggestions": ["gpt-4o", "gpt-4-turbo"] } },
+    "expectedKind": "ModelUnavailable",
+    "expectedUserMessage": "模型不可用"
+  },
+  {
+    "id": "model-003",
+    "raw": { "name": "ProviderModelNotFoundError", "data": { "providerID": "google", "modelID": "gemini-ultra" } },
+    "expectedKind": "ModelUnavailable",
+    "expectedUserMessage": "模型不可用"
+  },
+  {
+    "id": "model-004-unknown-degraded",
+    "raw": { "name": "UnknownError", "data": { "message": "model not found: claude-3-opus does not exist" } },
+    "expectedKind": "ModelUnavailable",
+    "expectedUserMessage": "模型不可用"
+  },
+  {
+    "id": "model-005-unknown-degraded",
+    "raw": { "name": "UnknownError", "data": { "message": "The model gpt-5 is not supported by this provider" } },
+    "expectedKind": "ModelUnavailable",
+    "expectedUserMessage": "模型不可用"
+  },
+  {
+    "id": "model-006-unknown-degraded",
+    "raw": { "name": "UnknownError", "data": { "message": "Model not available in your region" } },
+    "expectedKind": "ModelUnavailable",
+    "expectedUserMessage": "模型不可用"
+  },
+  {
+    "id": "poison-001-file-part",
+    "raw": { "name": "StructuredOutputError", "data": { "message": "AI_UnsupportedFunctionalityError: 'file part media type text/x-yaml'", "retries": 3 } },
+    "expectedKind": "SessionPoisoned",
+    "expectedUserMessage": "会话历史包含不兼容数据"
+  },
+  {
+    "id": "poison-002-tool-choice",
+    "raw": { "name": "UnknownError", "data": { "message": "Unsupported tool choice type: auto is not allowed" } },
+    "expectedKind": "SessionPoisoned",
+    "expectedUserMessage": "会话历史包含不兼容数据"
+  },
+  {
+    "id": "poison-003-localshell",
+    "raw": { "name": "APIError", "data": { "message": "Validation failed: localShell input does not match schema", "statusCode": 400, "isRetryable": false } },
+    "expectedKind": "SessionPoisoned",
+    "expectedUserMessage": "会话历史包含不兼容数据"
+  },
+  {
+    "id": "poison-004-zoderror",
+    "raw": { "name": "APIError", "data": { "message": "ZodError: expected object at local_shell config", "statusCode": 422, "isRetryable": false } },
+    "expectedKind": "SessionPoisoned",
+    "expectedUserMessage": "会话历史包含不兼容数据"
+  },
+  {
+    "id": "unknown-001-generic",
+    "raw": { "name": "UnknownError", "data": { "message": "An unexpected error occurred while processing the request" } },
+    "expectedKind": "UnknownUpstream",
+    "expectedUserMessage": "未知错误"
+  },
+  {
+    "id": "unknown-002-api-non-poison",
+    "raw": { "name": "APIError", "data": { "message": "Connection reset by server", "statusCode": 502, "isRetryable": true } },
+    "expectedKind": "UnknownUpstream",
+    "expectedUserMessage": "未知错误"
+  },
+  {
+    "id": "unknown-003-output-length",
+    "raw": { "name": "MessageOutputLengthError", "data": {} },
+    "expectedKind": "UnknownUpstream",
+    "expectedUserMessage": "未知错误"
+  },
+  {
+    "id": "unknown-004-aborted",
+    "raw": { "name": "MessageAbortedError", "data": { "message": "Message generation was aborted by user" } },
+    "expectedKind": "UnknownUpstream",
+    "expectedUserMessage": "未知错误"
+  }
+]

--- a/tests/handler/fixtures/trap-samples.json
+++ b/tests/handler/fixtures/trap-samples.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "trap-001-auth-with-poison-substring",
+    "description": "ProviderAuthError 的 message 恰好包含 'file part media type' 子串——不应判为 Poison",
+    "raw": { "name": "ProviderAuthError", "data": { "providerID": "anthropic", "message": "Authentication failed: the file part media type in your request is not supported by your current plan" } },
+    "expectedKind": "Unauthorized"
+  },
+  {
+    "id": "trap-002-context-with-tool-choice",
+    "description": "ContextOverflowError 的 message 恰好包含 'tool choice type'——不应判为 Poison",
+    "raw": { "name": "ContextOverflowError", "data": { "message": "Context overflow: tool choice type auto increased token usage beyond limit" } },
+    "expectedKind": "ContextOverflow"
+  },
+  {
+    "id": "trap-003-structured-output-no-poison",
+    "description": "StructuredOutputError 但 message 不含 poison pattern——不应判为 Poison",
+    "raw": { "name": "StructuredOutputError", "data": { "message": "Model did not produce structured output after 3 retries", "retries": 3 } },
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-004-structured-output-different-error",
+    "description": "StructuredOutputError 但 message 是其他内容——不应判为 Poison",
+    "raw": { "name": "StructuredOutputError", "data": { "message": "Output validation failed: missing required field 'result'", "retries": 1 } },
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-005-unknown-without-model-pattern",
+    "description": "UnknownError 但 message 不含 model 模式——应判 UnknownUpstream",
+    "raw": { "name": "UnknownError", "data": { "message": "Rate limit exceeded, please try again later" } },
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-006-string-throw",
+    "description": "纯字符串抛出物——应判 UnknownUpstream",
+    "raw": "something went wrong",
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-007-null-throw",
+    "description": "null 抛出物——应判 UnknownUpstream",
+    "raw": null,
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-008-number-throw",
+    "description": "数字抛出物——应判 UnknownUpstream",
+    "raw": 42,
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-009-plain-object",
+    "description": "普通对象无 name 字段——应判 UnknownUpstream",
+    "raw": { "code": "ERR_NETWORK", "message": "fetch failed" },
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-010-api-error-non-poison",
+    "description": "APIError 但 message 不含 poison pattern——不应判为 Poison",
+    "raw": { "name": "APIError", "data": { "message": "Request timeout after 30000ms", "statusCode": 504, "isRetryable": true } },
+    "expectedKind": "UnknownUpstream"
+  },
+  {
+    "id": "trap-011-model-not-found-in-poison-name",
+    "description": "UnknownError 同时含 model pattern 和 poison pattern——model 优先级高于 poison",
+    "raw": { "name": "UnknownError", "data": { "message": "model not found: file part media type unsupported" } },
+    "expectedKind": "ModelUnavailable"
+  },
+  {
+    "id": "trap-012-circular-ref",
+    "description": "循环引用对象——应判 UnknownUpstream 不崩溃",
+    "raw": "__CIRCULAR__",
+    "expectedKind": "UnknownUpstream"
+  }
+]


### PR DESCRIPTION
## Summary

- Replace recursive string scanning with `classify()` + `matchPluginError()` exhaustive handler
- `PluginError` discriminated union: 5 kinds (SessionPoisoned, ModelUnavailable, ContextOverflow, Unauthorized, UnknownUpstream)
- Priority chain: Auth → Context → Model → Poison → fallback (precision-inverted: strongest evidence first)
- `Evidence[]` audit trail for every classification decision
- `toLog()` outputs all fields including raw (local-only plugin, stderr no network transmission)
- Single classify call point in chat.ts catch block (FR-011)
- 73 unit tests: real samples (20), trap samples (12), edge cases (11), evidence completeness (6), priority chain (6), utilities (12), toLog (4), matchPluginError (1), PluginErrorThrown (1)

## Also included

- Qodana code quality CI workflow
- CLAUDE.md / AGENTS.md cleanup and restructuring
- Directory-level CLAUDE.md for `src/feishu/`, `src/handler/`, `src/tools/`, `src/utils/`
- action-bus.ts `subscribe()` return type enhancement
- index.ts OTEL stderr severity mapping (`otelStderrLinePrefix`)

## Test plan

- [x] `npx vitest run tests/handler/errors.test.ts` → 73/73 pass
- [x] `npm run typecheck` → clean
- [x] `npm run build` → success
- [ ] Manual: send message triggering ProviderAuthError → "认证失败" reply
- [ ] Manual: send message triggering ContextOverflowError → "对话历史过长" reply
- [ ] Manual: send message triggering model not found → auto recovery attempt
- [ ] Manual: send .yaml file → no `AI_UnsupportedFunctionalityError`