### PR TITLE
fix(v1.8.1): make initDedup idempotent — prevent dedup map reset on multi-instance bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",

--- a/src/feishu/CLAUDE.md
+++ b/src/feishu/CLAUDE.md
@@ -93,7 +93,7 @@
 **dedup.ts** — 消息去重
 - 使用 TtlMap 记录已处理的 messageId，默认 10 分钟窗口内自动去重
 - 防止飞书 WebSocket 在网络抖动或重连时重复投递同一事件
-- 通过 `initDedup(ttl)` 支持启动时自定义去重窗口
+- 通过 `initDedup(ttl)` 在启动时自定义去重窗口；**幂等**——已 init 即跳过，防止 multi-instance bootstrap 重置 dedup map（v1.8.1 hotfix）
 
 **group-filter.ts** — @提及检测
 - 遍历飞书消息 mentions 数组，与 bot 自身的 open_id 比较

--- a/src/feishu/dedup.ts
+++ b/src/feishu/dedup.ts
@@ -16,15 +16,28 @@ import { TtlMap } from "../utils/ttl-map.js"
 let dedup = new TtlMap<true>(10 * 60 * 1_000)
 
 /**
- * 初始化（或重置）去重缓存的过期时间
+ * 标记 initDedup 是否已被调用过。
  *
- * 在插件启动时调用，允许通过配置文件自定义去重窗口。
- * 调用后会创建全新的 TtlMap 实例，旧缓存被丢弃。
+ * OpenCode server-proxy multi-instance bootstrapping 下，FeishuPlugin 工厂可能
+ * 在同一进程内被多次调用（不同 directory 各触发一次 init）。如果每次都重建
+ * dedup map，已记录的 messageId 会被丢失，飞书 ack 重投机制下同消息会被处理两次。
+ *
+ * @see specs/028-lifecycle-invariants/spec.md FR-002
+ */
+let dedupInitialized = false
+
+/**
+ * 初始化去重缓存的过期时间。
+ *
+ * **幂等**：仅第一次调用生效，后续调用直接返回。
+ * 配置变更（dedupTtl）需重启 process 生效（daemon 标准行为）。
  *
  * @param ttl 去重窗口时长（毫秒）
  */
 export function initDedup(ttl: number): void {
+  if (dedupInitialized) return
   dedup = new TtlMap<true>(ttl)
+  dedupInitialized = true
 }
 
 /**


### PR DESCRIPTION
## TL;DR

v1.8.0 生产事故 hotfix。OpenCode server-proxy multi-instance bootstrapping 下，`FeishuPlugin` 工厂在同进程内被多次调用（每个 directory 一次），每次都调 `initDedup(ttl)` 重建 dedup map，导致已记录的 messageId 丢失。结合飞书 WS ack 重投机制（约 19-30s），同消息被处理两次 → token 翻倍消耗。

本 PR 加 `dedupInitialized` 守护让 `initDedup()` 幂等：第一次正常 init，后续调用直接返回。配置变更（dedupTtl）需重启 process 生效（daemon 标准行为）。

## 故障复现（来自 v1.8.0 stdout (2).log）

```
T=0.000s   WS₁ 收到 messageId om_x100... (L127)
T+0.245s   server-proxy 触发 directory 切换 → instance B bootstrap (L137)
T+0.875s   instance B 调 FeishuPlugin → initDedup() 重建 dedup map ★
T+18.475s  飞书 ack 超时重投 → isDuplicate() 返回 false → 处理第二次 (L207)
```

## 改动范围

| 文件 | 改动 |
|------|------|
| `src/feishu/dedup.ts` | 加 `dedupInitialized` 标记 + `if (dedupInitialized) return` 守护（17 行新代码包含注释） |
| `src/feishu/CLAUDE.md` | 同步 dedup.ts 描述为"幂等" |
| `package.json` | `1.8.0 → 1.8.1` |

**不动**的（留给完整 spec 028）：
- WS / larkClient / botOpenId 单例
- SIGTERM 兜底
- session-cache directory 维度
- SpecKit 流程修正（NG owner 字段等）

## 验证

- `npm run typecheck` ✅
- `npm run build` ✅
- 复盘 stdout (2).log 因果链：第一次 `initDedup()` 仍按用户配置 `dedupTtl` 重建 dedup map（运行在 startup 序列中，先于任何 `isDuplicate` 调用）；第二次起 noop，已记录的 messageId 保留 → 飞书 ack 重投被正确挡住

## 完整修复 spec

`specs/028-lifecycle-invariants/` 是完整的 plugin lifecycle invariants spec，覆盖 6 项 lifecycle FR + 3 项 SpecKit 流程治理 FR。本 hotfix 仅实施 spec 028 FR-002 的最小子集，止血生产 token 双消耗，让 028 完整 spec 走正常 plan/tasks/implement 流程。

## Test Plan

- [x] typecheck 通过
- [x] build 通过
- [ ] 手动验证：本地启动 OpenCode + opencode-feishu@1.8.1，触发 directory 切换，发送同 messageId 两次，第二次应被 dedup 挡住

## 边界 case 说明（reviewer 提出）

模块加载时 `dedup` 已用默认 10 分钟 TTL 创建。第一次 `initDedup(ttl)` 调用会用用户配置 ttl 重建 dedup map（覆盖默认实例）——前提是 `initDedup` 在任何 `isDuplicate` 之前被调用。当前调用拓扑下成立（`initDedup` 在 `startFeishuGateway` 之前，gateway 才触发 `isDuplicate`）。如果未来调用顺序改变需重新审视。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.8.1

* **Bug Fixes**
  * Fixed message deduplication initialization to be idempotent, preventing unintended cache resets during multi-instance deployments. This ensures deduplication state is preserved across initialization calls.

* **Documentation**
  * Updated documentation to clarify deduplication initialization behavior and its execution semantics in multi-instance environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->