### PR TITLE
fix(v1.8.2): register SIGTERM/SIGINT handler to gracefully stop WS gateway

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,11 @@ export const FeishuPlugin: Plugin = async (ctx) => {
   })
 
   // 把当前 gateway 加入活跃集合：handler 触发时遍历所有 gateway 统一关闭。
-  activeGateways.add(gateway)
+  // 加 null 守护是防御性的——当前 flow narrowing 后 gateway 已收窄为非 null，
+  // 但未来若 gateway 创建路径调整，守护可防止退化。
+  if (gateway) {
+    activeGateways.add(gateway)
+  }
 
   // 仅注册一次 SIGTERM/SIGINT 监听器（OpenCode plugin 接口无 destroy 钩子，
   // 用 process signal 兜底关闭 WS，避免飞书侧出现僵尸连接）。

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,18 @@ function loadFeishuRuntimePrompt(): string {
 const feishuRuntimePrompt = loadFeishuRuntimePrompt()
 
 /**
+ * 进程级 shutdown 状态。
+ *
+ * `latestGateway` 始终指向最近一次 `FeishuPlugin(ctx)` 调用创建的网关。
+ * `signalHandlersRegistered` 防止 SIGTERM/SIGINT 监听器在多 instance bootstrap
+ * 场景下被重复注册（OpenCode server-proxy 每个 directory 会调一次工厂）。
+ *
+ * @see specs/028-lifecycle-invariants/spec.md FR-005
+ */
+let latestGateway: FeishuGatewayResult | null = null
+let signalHandlersRegistered = false
+
+/**
  * OpenCode 插件入口导出。
  *
  * OpenCode 在加载插件时会调用这个工厂函数，
@@ -186,6 +198,30 @@ export const FeishuPlugin: Plugin = async (ctx) => {
     },
     log,
   })
+
+  // 更新进程级 shutdown 状态：handler 始终关闭最新一次 init 创建的网关。
+  latestGateway = gateway
+
+  // 仅注册一次 SIGTERM/SIGINT 监听器（OpenCode plugin 接口无 destroy 钩子，
+  // 用 process signal 兜底关闭 WS，避免飞书侧出现僵尸连接）。
+  if (!signalHandlersRegistered) {
+    signalHandlersRegistered = true
+    let stopping = false
+    const handleShutdown = (signal: NodeJS.Signals): void => {
+      // signal handler 必须幂等：多次收到同信号或不同信号时不重复关闭。
+      if (stopping) return
+      stopping = true
+      // 进程退出阶段 client.app.log 可能已失效，直接 stderr 输出。
+      console.error(`[feishu] received ${signal}, closing WS gateway`)
+      try {
+        latestGateway?.stop()
+      } catch (err) {
+        console.error(`[feishu] gateway.stop() failed during shutdown:`, err)
+      }
+    }
+    process.on("SIGTERM", handleShutdown)
+    process.on("SIGINT", handleShutdown)
+  }
 
   log("info", "飞书插件已初始化", {
     appId: resolvedConfig.appId.slice(0, 8) + "...",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,13 +84,15 @@ const feishuRuntimePrompt = loadFeishuRuntimePrompt()
 /**
  * 进程级 shutdown 状态。
  *
- * `latestGateway` 始终指向最近一次 `FeishuPlugin(ctx)` 调用创建的网关。
- * `signalHandlersRegistered` 防止 SIGTERM/SIGINT 监听器在多 instance bootstrap
- * 场景下被重复注册（OpenCode server-proxy 每个 directory 会调一次工厂）。
+ * `activeGateways` 存储所有由 `FeishuPlugin(ctx)` 调用创建的活跃网关。multi-instance
+ * bootstrap 场景下（OpenCode server-proxy 每个 directory 会调一次工厂），每次 init 都会
+ * 把新 gateway 加入集合，shutdown 时统一遍历关闭，确保所有 WSClient 都被释放。
+ *
+ * `signalHandlersRegistered` 防止 SIGTERM/SIGINT 监听器在多 instance 场景下被重复注册。
  *
  * @see specs/028-lifecycle-invariants/spec.md FR-005
  */
-let latestGateway: FeishuGatewayResult | null = null
+const activeGateways = new Set<FeishuGatewayResult>()
 let signalHandlersRegistered = false
 
 /**
@@ -199,8 +201,8 @@ export const FeishuPlugin: Plugin = async (ctx) => {
     log,
   })
 
-  // 更新进程级 shutdown 状态：handler 始终关闭最新一次 init 创建的网关。
-  latestGateway = gateway
+  // 把当前 gateway 加入活跃集合：handler 触发时遍历所有 gateway 统一关闭。
+  activeGateways.add(gateway)
 
   // 仅注册一次 SIGTERM/SIGINT 监听器（OpenCode plugin 接口无 destroy 钩子，
   // 用 process signal 兜底关闭 WS，避免飞书侧出现僵尸连接）。
@@ -212,12 +214,19 @@ export const FeishuPlugin: Plugin = async (ctx) => {
       if (stopping) return
       stopping = true
       // 进程退出阶段 client.app.log 可能已失效，直接 stderr 输出。
-      console.error(`[feishu] received ${signal}, closing WS gateway`)
-      try {
-        latestGateway?.stop()
-      } catch (err) {
-        console.error(`[feishu] gateway.stop() failed during shutdown:`, err)
+      console.error(`[feishu] received ${signal}, closing ${activeGateways.size} WS gateway(s)`)
+      for (const g of activeGateways) {
+        try {
+          g.stop()
+        } catch (err) {
+          console.error(`[feishu] gateway.stop() failed during shutdown:`, err)
+        }
       }
+      activeGateways.clear()
+      // 不调 process.exit：plugin 不应替 OpenCode 决定进程退出策略。
+      // OpenCode server 自己应 install signal listener 驱动 graceful shutdown；
+      // 若上游未 install listener，本 handler 仍能完成 WS 关闭，process 退出由
+      // 上游进程或 SIGKILL 兜底（透传原则——plugin 不染指主进程生命周期）。
     }
     process.on("SIGTERM", handleShutdown)
     process.on("SIGINT", handleShutdown)


### PR DESCRIPTION
## TL;DR

实施 spec 028 FR-005 — process 收到 SIGTERM/SIGINT 时调 `gateway.stop()` 关闭飞书 WS。OpenCode plugin 接口无 destroy 钩子，进程退出时 WSClient 不会被显式关闭，飞书侧需 60s 心跳超时才能清理僵尸连接。

## 改动范围

| 文件 | 改动 |
|------|------|
| `src/index.ts` | 模块级 `latestGateway` + `signalHandlersRegistered` 状态；工厂内注册 SIGTERM/SIGINT handler 调 `gateway.stop()`（+36 行） |
| `package.json` | `1.8.1 → 1.8.2` |

## 设计选择

1. **模块级 `latestGateway` 引用**：每次 plugin init 更新；handler 关闭最新一次创建的 gateway。multi-instance bootstrap 场景下旧 gateway 仍泄漏（FR-003 WS singleton 会修），但比 zero 关闭好。
2. **`signalHandlersRegistered` 防重注册**：multi-instance 场景下 plugin 工厂被多次调用，但 handler 只注册一次。
3. **handler 内部幂等**：用 `stopping` flag 防止多次 signal 触发重复关闭。
4. **用 console.error 替代 LogFn**：进程退出阶段 `client.app.log` 可能已失效（OpenCode 进程关闭后 log endpoint 不可达），直接 stderr 更可靠。

## 不动的

- WSClient / larkClient / botOpenId 单例化（FR-003/004/006）— 留给完整 spec 028 plan 阶段
- 配置文件运行时读取（FR-001 完整版）
- 其他 module-level state cleanup

## 验证

- `npm run typecheck` ✅
- `npm run build` ✅
- 手动验证（建议）：本地启动 OpenCode + opencode-feishu@1.8.2，`kill -TERM <pid>`，stderr 应出现 `[feishu] received SIGTERM, closing WS gateway` + lark SDK 的 `ws disconnect` 日志。

## Test Plan

- [x] typecheck 通过
- [x] build 通过
- [ ] 部署到 pay-dev-agent 后观察 process restart 时是否优雅关闭 WS

## 相关

- spec 028 FR-005: \`process 收到 SIGTERM 或 SIGINT 时，必须调用 gateway.stop() 关闭 WS。signal handler 必须幂等\`
- v1.8.1 hotfix（PR #70）解决了 dedup map 重建问题；本 PR 解决资源关闭问题。两者独立修复，不相互依赖。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown: ensures active connections are closed, prevents re-entrant shutdown, and emits shutdown progress/errors to standard error while allowing the host to control process termination.

* **Chores**
  * Patch version bumped from 1.8.1 to 1.8.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->