### PR TITLE
fix: remove UUID messageID that breaks OpenCode runLoop ID ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -12,7 +12,6 @@
 import type { FeishuMessageContext, ResolvedConfig, LogFn } from "../types.js"
 import type { OpencodeClient } from "@opencode-ai/sdk"
 import type { OpencodeClient as V2OpencodeClient } from "@opencode-ai/sdk/v2/client"
-import { randomUUID } from "node:crypto"
 import * as sender from "../feishu/sender.js"
 import {
   registerPending, unregisterPending,
@@ -32,7 +31,6 @@ import type { CardKitClient } from "../feishu/cardkit.js"
 import { StreamingCard } from "../feishu/streaming-card.js"
 import { handlePermissionRequested, handleQuestionRequested, type InteractiveDeps } from "./interactive.js"
 import {
-  addRunRequestMessageId,
   attachRunCard,
   completeReplyRun,
   createReplyRun,
@@ -99,34 +97,19 @@ function traceLangfuseUser(
 }
 
 /**
- * 为当前 prompt 生成稳定的 user messageID。
- *
- * 后续回读实际模型时，只认和这个 ID 关联出来的 assistant message，
- * 避免把上一轮对话的模型误展示到当前卡片。
- */
-function createPromptMessageId(): string {
-  return `msg_${randomUUID()}`
-}
-
-/**
- * 从当前请求关联的 assistant message 读取实际执行模型。
- *
- * 这里优先信任运行结果本身的 `providerID/modelID`，
- * 而不是配置里的默认模型，避免自动恢复或局部 override 后显示错误。
+ * 从 session 最后一条 assistant message 读取实际执行模型。
  */
 async function fetchActualModel(
   client: OpencodeClient,
   sessionId: string,
-  requestMessageIds: readonly string[],
   log: LogFn,
   query?: { directory?: string },
 ): Promise<string | undefined> {
   try {
     const { data: messages } = await client.session.messages({ path: { id: sessionId }, query })
-    return extractAssistantModelForRequests(messages ?? [], requestMessageIds)
+    return extractAssistantModel(messages ?? [])
   } catch (err) {
-    // 模型信息只影响卡片辅助展示；读取失败时回退为不展示模型。
-    log("error", "读取本次 assistant 实际模型失败", {
+    log("error", "读取 assistant 实际模型失败", {
       sessionId,
       error: err instanceof Error ? err.message : String(err),
     })
@@ -368,7 +351,6 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     chatType,
   })
   // 当前用户可见这一轮可能会产生多次 prompt（原始尝试 + 自动恢复），统一记录它们的 messageID。
-  const requestMessageIds: string[] = []
   const detailPhases = new Map<string, DetailPhaseSnapshot>()
   let latestSnapshot: AssistantSnapshot = { text: "", reasoning: "" }
   let timedOut = false
@@ -541,7 +523,6 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     },
   ) => pollForResponse(currentClient, currentSessionId, {
     ...pollOptions,
-    requestMessageIds,
     onSnapshot: handleSnapshot,
     onTick: syncObservedRunState,
     onTimedOut: () => {
@@ -552,14 +533,10 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
   try {
     // 清除前次遗留的 session error 缓存，避免 pollForResponse 误检测旧错误。
     clearSessionError(session.id)
-    const requestMessageId = createPromptMessageId()
-    requestMessageIds.push(requestMessageId)
-    addRunRequestMessageId(run.runId, requestMessageId)
-
     await client.session.promptAsync({
       path: { id: session.id },
       query,
-      body: { ...baseBody, messageID: requestMessageId },
+      body: baseBody,
     })
 
     observedRunState = "running"
@@ -584,7 +561,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     // prompt 成功：清空该 sessionKey 的自动恢复计数。
     clearRetryAttempts(sessionKey)
 
-    const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+    const actualModel = await fetchActualModel(client, session.id, log, query)
     const terminalState = timedOut ? "timed_out" : "completed"
     completeReplyRun(run.runId, terminalState)
     observedRunState = terminalState
@@ -611,7 +588,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       if (streamingCard) {
         await streamingCard.setRunState("aborted", "aborted")
       }
-      const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+      const actualModel = await fetchActualModel(client, session.id, log, query)
       await finalizeReply({
         streamingCard,
         feishuClient,
@@ -655,15 +632,12 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
           if (cleaned) {
             timedOut = false
             clearSessionError(session.id)
-            const recoveryRequestMessageId = createPromptMessageId()
-            requestMessageIds.push(recoveryRequestMessageId)
-            addRunRequestMessageId(run.runId, recoveryRequestMessageId)
 
             try {
               await client.session.promptAsync({
                 path: { id: session.id },
                 query,
-                body: { ...baseBody, messageID: recoveryRequestMessageId },
+                body: baseBody,
               })
 
               const finalText = await poll(client, session.id, {
@@ -671,7 +645,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
                 signal: mergeAbortSignals([signal, getRunAbortSignal(run.runId)]),
               })
 
-              const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+              const actualModel = await fetchActualModel(client, session.id, log, query)
               const terminalState = timedOut ? "timed_out" : "completed"
               completeReplyRun(run.runId, terminalState)
               if (streamingCard) {
@@ -714,12 +688,8 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
 
       ModelUnavailable: async (e) => {
         timedOut = false
-        const recoveryRequestMessageId = createPromptMessageId()
-        requestMessageIds.push(recoveryRequestMessageId)
-        addRunRequestMessageId(run.runId, recoveryRequestMessageId)
         const recovery = await tryModelRecovery({
           pluginError: e, sessionId: session.id, sessionKey, client, directory,
-          requestMessageId: recoveryRequestMessageId,
           parts,
           timeout,
           pollInterval,
@@ -731,7 +701,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
         })
 
         if (recovery.recovered) {
-          const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+          const actualModel = await fetchActualModel(client, session.id, log, query)
           const terminalState = timedOut ? "timed_out" : "completed"
           completeReplyRun(run.runId, terminalState)
           if (streamingCard) {
@@ -752,7 +722,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
           return
         }
         // 恢复失败：显示原始模型错误。
-        const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+        const actualModel = await fetchActualModel(client, session.id, log, query)
         completeReplyRun(run.runId, "failed")
         if (streamingCard) {
           await streamingCard.setRunState("failed", "failed")
@@ -817,7 +787,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
           hint: e.hint,
           error: thrownError,
         })
-        const actualModel = await fetchActualModel(client, session.id, requestMessageIds, log, query)
+        const actualModel = await fetchActualModel(client, session.id, log, query)
         completeReplyRun(run.runId, "failed")
         if (streamingCard) {
           await streamingCard.setRunState("failed", "failed")
@@ -912,13 +882,12 @@ async function pollForResponse(
     stablePolls: number
     query?: { directory: string }
     signal?: AbortSignal
-    requestMessageIds?: readonly string[]
     onSnapshot?: (snapshot: AssistantSnapshot) => void | Promise<void>
     onTick?: () => void | Promise<void>
     onTimedOut?: () => void
   },
 ): Promise<string> {
-  const { timeout, pollInterval, stablePolls, query, signal, requestMessageIds, onSnapshot, onTick, onTimedOut } = opts
+  const { timeout, pollInterval, stablePolls, query, signal, onSnapshot, onTick, onTimedOut } = opts
   // 轮询开始时间，用于超时判断。
   const start = Date.now()
   // 最近一次看到的 assistant 快照。
@@ -965,7 +934,7 @@ async function pollForResponse(
       }
 
       const { data: messages } = await client.session.messages({ path: { id: sessionId }, query })
-      const snapshot = extractAssistantSnapshotForRequests(messages ?? [], requestMessageIds)
+      const snapshot = extractLastAssistantSnapshot(messages ?? [])
 
       if (hasAssistantSnapshotChanged(snapshot, lastSnapshot)) {
         // 看到新快照：更新并重置稳定计数。
@@ -993,7 +962,7 @@ async function pollForResponse(
 
     // 再 fetch 一次最终消息列表，尽可能拿到最完整文本。
     const { data: finalMessages } = await client.session.messages({ path: { id: sessionId }, query })
-    const finalSnapshot = extractAssistantSnapshotForRequests(finalMessages ?? [], requestMessageIds)
+    const finalSnapshot = extractLastAssistantSnapshot(finalMessages ?? [])
     if (hasAssistantSnapshotChanged(finalSnapshot, lastSnapshot) && onSnapshot) {
       await onSnapshot(finalSnapshot)
     }
@@ -1107,69 +1076,30 @@ function extractLastAssistantSnapshot(
   }
 }
 
-function extractAssistantSnapshotForRequests(
-  messages: Array<{
-    info: { role?: string; parentID?: unknown; [key: string]: unknown }
-    parts: Array<{ type?: string; text?: string; [key: string]: unknown }>
-  }>,
-  requestMessageIds?: readonly string[],
-): AssistantSnapshot {
-  if (!requestMessageIds || requestMessageIds.length === 0) {
-    return extractLastAssistantSnapshot(messages)
-  }
-
-  const requestIdSet = new Set(requestMessageIds)
-  for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const message = messages[index]
-    const info = message?.info
-    if (info?.role !== "assistant") continue
-    const parentID = typeof info.parentID === "string" ? info.parentID.trim() : ""
-    if (!parentID || !requestIdSet.has(parentID)) continue
-    return extractLastAssistantSnapshot([message])
-  }
-
-  return { text: "", reasoning: "" }
-}
-
 function hasAssistantSnapshotChanged(next: AssistantSnapshot, current: AssistantSnapshot): boolean {
   return next.text !== current.text || next.reasoning !== current.reasoning
 }
 
 /**
- * 从当前请求关联的 assistant message 提取真实执行模型。
- *
- * 这里只认 `parentID` 命中的 assistant message，
- * 避免把历史轮次的模型串到当前卡片里。
+ * 从 session 最后一条 assistant message 提取 providerID/modelID。
  */
-function extractAssistantModelForRequests(
+function extractAssistantModel(
   messages: Array<{
     info: {
       role?: string
-      parentID?: unknown
       providerID?: unknown
       modelID?: unknown
       [key: string]: unknown
     }
   }>,
-  requestMessageIds: readonly string[],
 ): string | undefined {
-  if (requestMessageIds.length === 0) return undefined
-  const requestIdSet = new Set(requestMessageIds)
-
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const assistant = messages[index]?.info
     if (assistant?.role !== "assistant") continue
-
-    const parentID = typeof assistant.parentID === "string" ? assistant.parentID.trim() : ""
-    if (!parentID || !requestIdSet.has(parentID)) continue
-
     const providerID = typeof assistant.providerID === "string" ? assistant.providerID.trim() : ""
     const modelID = typeof assistant.modelID === "string" ? assistant.modelID.trim() : ""
-    // 同一轮里可能先出现一个尚未补全模型字段的 assistant 记录，此时继续向前找稳定记录。
     if (!providerID || !modelID) continue
-
     return `${providerID}/${modelID}`
   }
-
   return undefined
 }

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -520,6 +520,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       stablePolls: number
       query?: { directory: string }
       signal?: AbortSignal
+      baseline?: AssistantSnapshot
     },
   ) => pollForResponse(currentClient, currentSessionId, {
     ...pollOptions,
@@ -533,6 +534,12 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
   try {
     // 清除前次遗留的 session error 缓存，避免 pollForResponse 误检测旧错误。
     clearSessionError(session.id)
+
+    // 捕获 baseline：promptAsync 前的最后一条 assistant 快照。
+    // 复用 session 时，轮询必须忽略与 baseline 相同的旧 turn 快照。
+    const { data: baselineMessages } = await client.session.messages({ path: { id: session.id }, query }).catch(() => ({ data: undefined }))
+    const baseline = extractLastAssistantSnapshot(baselineMessages ?? [])
+
     await client.session.promptAsync({
       path: { id: session.id },
       query,
@@ -550,6 +557,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       stablePolls,
       query,
       signal: mergeAbortSignals([signal, getRunAbortSignal(run.runId)]),
+      baseline,
     })
 
     log("info", "模型响应完成", {
@@ -882,12 +890,14 @@ async function pollForResponse(
     stablePolls: number
     query?: { directory: string }
     signal?: AbortSignal
+    /** promptAsync 前捕获的 baseline，用于忽略旧 turn 的快照。 */
+    baseline?: AssistantSnapshot
     onSnapshot?: (snapshot: AssistantSnapshot) => void | Promise<void>
     onTick?: () => void | Promise<void>
     onTimedOut?: () => void
   },
 ): Promise<string> {
-  const { timeout, pollInterval, stablePolls, query, signal, onSnapshot, onTick, onTimedOut } = opts
+  const { timeout, pollInterval, stablePolls, query, signal, baseline, onSnapshot, onTick, onTimedOut } = opts
   // 轮询开始时间，用于超时判断。
   const start = Date.now()
   // 最近一次看到的 assistant 快照。
@@ -935,6 +945,12 @@ async function pollForResponse(
 
       const { data: messages } = await client.session.messages({ path: { id: sessionId }, query })
       const snapshot = extractLastAssistantSnapshot(messages ?? [])
+
+      // 忽略与 baseline 相同的快照（旧 turn 的回复），避免复用 session 时提前收敛。
+      if (baseline && !hasAssistantSnapshotChanged(snapshot, baseline)) {
+        // 快照与 baseline 相同，说明新 turn 尚未产生输出，继续等待。
+        continue
+      }
 
       if (hasAssistantSnapshotChanged(snapshot, lastSnapshot)) {
         // 看到新快照：更新并重置稳定计数。
@@ -1081,7 +1097,7 @@ function hasAssistantSnapshotChanged(next: AssistantSnapshot, current: Assistant
 }
 
 /**
- * 从 session 最后一条 assistant message 提取 providerID/modelID。
+ * 从 session 消息列表末尾反向查找，提取第一个包含完整 providerID/modelID 的 assistant message。
  */
 function extractAssistantModel(
   messages: Array<{

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -979,10 +979,14 @@ async function pollForResponse(
     // 再 fetch 一次最终消息列表，尽可能拿到最完整文本。
     const { data: finalMessages } = await client.session.messages({ path: { id: sessionId }, query })
     const finalSnapshot = extractLastAssistantSnapshot(finalMessages ?? [])
-    if (hasAssistantSnapshotChanged(finalSnapshot, lastSnapshot) && onSnapshot) {
-      await onSnapshot(finalSnapshot)
+    // 忽略与 baseline 相同的旧 turn 快照，避免返回上一轮的文本。
+    const effectiveSnapshot = (baseline && !hasAssistantSnapshotChanged(finalSnapshot, baseline))
+      ? lastSnapshot
+      : finalSnapshot
+    if (hasAssistantSnapshotChanged(effectiveSnapshot, lastSnapshot) && onSnapshot) {
+      await onSnapshot(effectiveSnapshot)
     }
-    return finalSnapshot.text || lastSnapshot.text
+    return effectiveSnapshot.text || lastSnapshot.text
   } finally {
     unsub()
   }
@@ -1110,10 +1114,12 @@ function extractAssistantModel(
   }>,
 ): string | undefined {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
-    const assistant = messages[index]?.info
-    if (assistant?.role !== "assistant") continue
-    const providerID = typeof assistant.providerID === "string" ? assistant.providerID.trim() : ""
-    const modelID = typeof assistant.modelID === "string" ? assistant.modelID.trim() : ""
+    const info = messages[index]?.info
+    // 遇到 user message 说明已离开当前 turn，停止搜索避免拾取旧 turn 的模型信息。
+    if (info?.role === "user") break
+    if (info?.role !== "assistant") continue
+    const providerID = typeof info.providerID === "string" ? info.providerID.trim() : ""
+    const modelID = typeof info.modelID === "string" ? info.modelID.trim() : ""
     if (!providerID || !modelID) continue
     return `${providerID}/${modelID}`
   }

--- a/src/handler/error-recovery.ts
+++ b/src/handler/error-recovery.ts
@@ -103,7 +103,6 @@ export async function tryModelRecovery(params: {
   readonly sessionKey: string
   readonly client: OpencodeClient
   readonly directory?: string
-  readonly requestMessageId: string
   readonly parts: readonly PromptPart[]
   readonly timeout?: number
   readonly pollInterval: number
@@ -115,7 +114,6 @@ export async function tryModelRecovery(params: {
 }): Promise<RecoveryResult> {
   const {
     pluginError, sessionId, sessionKey, client, directory,
-    requestMessageId,
     parts, timeout, pollInterval, stablePolls, query, signal,
     log, poll,
   } = params
@@ -163,8 +161,7 @@ export async function tryModelRecovery(params: {
     await client.session.promptAsync({
       path: { id: sessionId },
       query,
-      // 恢复尝试也显式绑定一个 user messageID，便于上层只读取这次尝试的实际模型。
-      body: { parts: [...parts], model: modelOverride, messageID: requestMessageId },
+      body: { parts: [...parts], model: modelOverride },
     })
 
     const finalText = await poll(client, sessionId, {

--- a/src/handler/reply-run-registry.ts
+++ b/src/handler/reply-run-registry.ts
@@ -27,7 +27,6 @@ export interface ActiveReplyRun {
   endedAt?: string
   cardMessageId?: string
   cardId?: string
-  requestMessageIds: string[]
   abortRequestedAt?: string
   abortSource?: "card" | "message" | "system"
   /** 进入 aborting 前的非终态；abort 失败时用于恢复，避免硬重置到 running。 */
@@ -69,7 +68,6 @@ export function createReplyRun(params: {
     chatType: params.chatType,
     state: "starting",
     startedAt: new Date().toISOString(),
-    requestMessageIds: [],
     controller: new AbortController(),
   }
 
@@ -84,16 +82,6 @@ export function attachRunCard(runId: string, card: { cardId?: string; cardMessag
   if (card.cardId) run.cardId = card.cardId
   if (card.cardMessageId) run.cardMessageId = card.cardMessageId
   cacheRun(run)
-  return run
-}
-
-export function addRunRequestMessageId(runId: string, messageId: string): ActiveReplyRun | undefined {
-  const run = getRunByRunId(runId)
-  if (!run) return undefined
-  if (messageId && !run.requestMessageIds.includes(messageId)) {
-    run.requestMessageIds.push(messageId)
-    cacheRun(run)
-  }
   return run
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `createPromptMessageId()` generated UUID-format messageID (`msg_550e8400-...`) which sorts lexicographically BEFORE OpenCode's timestamp-encoded ascending IDs (`msg_e01a4a...`). When reusing an old session, OpenCode's `runLoop` backward scan compares `lastUser.id < lastAssistant.id` — the UUID being "smaller" made this `true`, causing the loop to exit at `step=0` without calling the LLM, resulting in empty responses.
- **Fix**: Stop passing `messageID` to `promptAsync`, let OpenCode generate its own timestamp-encoded IDs. `fetchActualModel` now reads the last assistant message directly instead of matching by `parentID`.
- **History**: v1.7.6 worked because it didn't pass `messageID`; the custom UUID was added in v1.7.7 as a preventive fix for a hypothetical model display issue that was never actually reported.

## Changes

| File | Change |
|------|--------|
| `chat.ts` | Remove `createPromptMessageId()`, `randomUUID` import, `requestMessageIds` tracking, `messageID` from all `promptAsync` calls. Replace `extractAssistantSnapshotForRequests`/`extractAssistantModelForRequests` with `extractAssistantModel` (last assistant message). |
| `error-recovery.ts` | Remove `requestMessageId` param and `messageID` from `promptAsync` call |
| `reply-run-registry.ts` | Remove `requestMessageIds` field and `addRunRequestMessageId` function |

## Test plan

- [ ] Verify `npm run typecheck` passes
- [ ] Send a message to a Feishu bot that has an existing session with a previous completed assistant response
- [ ] Verify the bot responds (not empty)
- [ ] Verify model name displays correctly in streaming card footer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.10.7
  * Internal refactoring and optimization of message handling and model tracking logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->