### PR TITLE
fix: observability for orphan session.error + baseline log + doc sync

### DIFF
--- a/CLAUDE.reply-rendering.md
+++ b/CLAUDE.reply-rendering.md
@@ -3,9 +3,13 @@
 > 项目架构文档（运行时数据流视图）。基于源码精确反推：从 OpenCode SSE 事件到飞书 CardKit 卡片的完整转换链路。
 
 **文档类型**: 架构文档（运行时 process view）
-**最近更新**: 2026-05-06（v1.10.5 § 2 改为字段级全景图 + 新增 § 10 管道数据类型参考）
-**适用版本**: v1.10.5+
+**最近更新**: 2026-05-08（v1.10.7 baseline 机制注记 + § 1a/§ 3/§ 6 delta 路径标注为已删除）
+**适用版本**: v1.10.7+
 **范围**: 主回复路径（StreamingCard）；**不覆盖**独立卡片（`feishu_send_card` tool）、form 交互、权限/问答卡片
+
+> ⚠️ **本文档与代码版本对应说明**：
+> - § 1a / § 3 中提到的 `message.part.delta` 累积路径已在 v1.10.5 删除（PR #74），主回复仅依赖 `message.part.updated` 全量快照。
+> - v1.10.7 新增 baseline 机制：`pollForResponse` 之前抓 baseline 快照，轮询时跳过与 baseline 相同的旧 turn 回复，避免复用 session 时把上一轮文本误当本轮输出。详见 `src/handler/CLAUDE.md` chat.ts 章节。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-feishu",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "OpenCode 飞书插件 — 通过飞书 WebSocket 长连接接入 OpenCode AI 对话",
   "type": "module",
   "main": "dist/index.js",

--- a/src/handler/CLAUDE.md
+++ b/src/handler/CLAUDE.md
@@ -22,10 +22,12 @@
 ## 文件职责
 
 **chat.ts** — 核心对话处理器
-- `handleChat()` 完整走完一条飞书消息：绑定 session → 构造 prompt → `promptAsync()` 异步发送 → 轮询等待输出稳定 → 写回飞书
+- `handleChat()` 完整走完一条飞书消息：绑定 session → 捕获 baseline → 构造 prompt → `promptAsync()` 异步发送 → 轮询等待输出稳定 → 写回飞书
 - 启动 StreamingCard（CardKit 不可用时降级为纯文本占位），通过 action-bus 订阅 text-updated / tool-state-changed / permission / question 事件实时更新卡片
 - 轮询期间每轮检查 SSE 缓存错误，检测到 `SessionErrorDetected` 立即终止
 - catch 块是 `classify()` 的**唯一调用点**（FR-011）：通过 `matchPluginError` exhaustive handler 分发到具体错误处理路径
+
+**baseline 机制（v1.10.7 引入）**：`promptAsync` 之前抓一张 `extractLastAssistantSnapshot` 作为 baseline，传给 `pollForResponse`。轮询过程中若 snapshot 与 baseline 完全相同（旧 turn 的回复未变），跳过本轮不累计 `sameCount`。这避免了"复用 session + 新 turn 慢"场景下 stable 检查在第一次轮询就被旧文本满足，把上一轮回复误当作本轮输出返回。捕获时打 `[feishu] baseline captured` 日志，含 `hasBaseline` / `textLen`，用于事后验证修复是否生效。
 
 **event.ts** — SSE 事件分发与状态缓存
 - `handleEvent()` 接收 OpenCode 事件，按类型分发：`message.part.updated` 更新占位消息或卡片，`permission.asked` / `question.asked` / `session.idle` 转发到 action-bus

--- a/src/handler/CLAUDE.md
+++ b/src/handler/CLAUDE.md
@@ -27,7 +27,7 @@
 - 轮询期间每轮检查 SSE 缓存错误，检测到 `SessionErrorDetected` 立即终止
 - catch 块是 `classify()` 的**唯一调用点**（FR-011）：通过 `matchPluginError` exhaustive handler 分发到具体错误处理路径
 
-**baseline 机制（v1.10.7 引入）**：`promptAsync` 之前抓一张 `extractLastAssistantSnapshot` 作为 baseline，传给 `pollForResponse`。轮询过程中若 snapshot 与 baseline 完全相同（旧 turn 的回复未变），跳过本轮不累计 `sameCount`。这避免了"复用 session + 新 turn 慢"场景下 stable 检查在第一次轮询就被旧文本满足，把上一轮回复误当作本轮输出返回。捕获时打 `[feishu] baseline captured` 日志，含 `hasBaseline` / `textLen` / `reasoningLen`，用于事后验证修复是否生效。
+**baseline 机制（v1.10.7 引入）**：`promptAsync` 之前抓一张 `extractLastAssistantSnapshot` 作为 baseline，传给 `pollForResponse`。轮询过程中若 snapshot 与 baseline 完全相同（旧 turn 的回复未变），跳过本轮不累计 `sameCount`。这避免了"复用 session + 新 turn 慢"场景下 stable 检查在第一次轮询就被旧文本满足，把上一轮回复误当作本轮输出返回。捕获时调用 `log("info", "baseline captured", ...)`，渲染后形态为 `[feishu] baseline captured`（`[feishu]` 前缀由 `src/index.ts` 的 `LOG_PREFIX` 自动添加，源码中**勿手动加**），含 `sessionKey` / `sessionId` / `fetchSuccess` / `hasBaseline` / `textLen` / `reasoningLen`，用于事后验证修复是否生效。
 
 **event.ts** — SSE 事件分发与状态缓存
 - `handleEvent()` 接收 OpenCode 事件，按类型分发：`message.part.updated` 更新占位消息或卡片，`permission.asked` / `question.asked` / `session.idle` 转发到 action-bus

--- a/src/handler/CLAUDE.md
+++ b/src/handler/CLAUDE.md
@@ -27,7 +27,7 @@
 - 轮询期间每轮检查 SSE 缓存错误，检测到 `SessionErrorDetected` 立即终止
 - catch 块是 `classify()` 的**唯一调用点**（FR-011）：通过 `matchPluginError` exhaustive handler 分发到具体错误处理路径
 
-**baseline 机制（v1.10.7 引入）**：`promptAsync` 之前抓一张 `extractLastAssistantSnapshot` 作为 baseline，传给 `pollForResponse`。轮询过程中若 snapshot 与 baseline 完全相同（旧 turn 的回复未变），跳过本轮不累计 `sameCount`。这避免了"复用 session + 新 turn 慢"场景下 stable 检查在第一次轮询就被旧文本满足，把上一轮回复误当作本轮输出返回。捕获时打 `[feishu] baseline captured` 日志，含 `hasBaseline` / `textLen`，用于事后验证修复是否生效。
+**baseline 机制（v1.10.7 引入）**：`promptAsync` 之前抓一张 `extractLastAssistantSnapshot` 作为 baseline，传给 `pollForResponse`。轮询过程中若 snapshot 与 baseline 完全相同（旧 turn 的回复未变），跳过本轮不累计 `sameCount`。这避免了"复用 session + 新 turn 慢"场景下 stable 检查在第一次轮询就被旧文本满足，把上一轮回复误当作本轮输出返回。捕获时打 `[feishu] baseline captured` 日志，含 `hasBaseline` / `textLen` / `reasoningLen`，用于事后验证修复是否生效。
 
 **event.ts** — SSE 事件分发与状态缓存
 - `handleEvent()` 接收 OpenCode 事件，按类型分发：`message.part.updated` 更新占位消息或卡片，`permission.asked` / `question.asked` / `session.idle` 转发到 action-bus

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -541,6 +541,8 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     const baseline = extractLastAssistantSnapshot(baselineMessages ?? [])
     log("info", "baseline captured", {
       sessionId: session.id,
+      // fetchSuccess=false 区分"fetch 失败"和"session 真的为空"——两者都会 hasBaseline=false 但语义不同。
+      fetchSuccess: baselineMessages !== undefined,
       hasBaseline: baseline.text.length > 0 || baseline.reasoning.length > 0,
       textLen: baseline.text.length,
       reasoningLen: baseline.reasoning.length,

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -543,6 +543,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       sessionId: session.id,
       hasBaseline: baseline.text.length > 0 || baseline.reasoning.length > 0,
       textLen: baseline.text.length,
+      reasoningLen: baseline.reasoning.length,
     })
 
     await client.session.promptAsync({

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -540,6 +540,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     const { data: baselineMessages } = await client.session.messages({ path: { id: session.id }, query }).catch(() => ({ data: undefined }))
     const baseline = extractLastAssistantSnapshot(baselineMessages ?? [])
     log("info", "baseline captured", {
+      sessionKey,
       sessionId: session.id,
       // fetchSuccess=false 区分"fetch 失败"和"session 真的为空"——两者都会 hasBaseline=false 但语义不同。
       fetchSuccess: baselineMessages !== undefined,

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -539,6 +539,11 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
     // 复用 session 时，轮询必须忽略与 baseline 相同的旧 turn 快照。
     const { data: baselineMessages } = await client.session.messages({ path: { id: session.id }, query }).catch(() => ({ data: undefined }))
     const baseline = extractLastAssistantSnapshot(baselineMessages ?? [])
+    log("info", "baseline captured", {
+      sessionId: session.id,
+      hasBaseline: baseline.text.length > 0 || baseline.reasoning.length > 0,
+      textLen: baseline.text.length,
+    })
 
     await client.session.promptAsync({
       path: { id: session.id },

--- a/src/handler/event.ts
+++ b/src/handler/event.ts
@@ -316,7 +316,10 @@ function handleSessionErrorEvent(event: Event, deps: EventDeps): void {
     errMsg = String(error)
   }
 
-  deps.log("warn", "收到 session.error 事件", { sessionId, errMsg })
+  // orphan = 错误属于未注册的 session（典型场景：启动期 plugin/MCP 加载失败）；
+  // 这类错误没有主链路消费 sessionErrors 缓存，只能靠日志暴露给运维。
+  const orphan = !pendingBySession.has(sessionId)
+  deps.log("warn", "收到 session.error 事件", { sessionId, errMsg, orphan })
 
   sessionErrors.set(sessionId, { message: errMsg, raw: error })
 


### PR DESCRIPTION
## Summary

Fixes 4 plugin-side issues identified by 6-agent parallel analysis of stderr.log.

**P0 — orphan session.error visibility** (`src/handler/event.ts`)
`session.error` events emitted during plugin/MCP startup (e.g. `superpowers` ENOENT) carry a sessionID that's never registered in `pendingBySession`, so the cached error gets evicted by TTL without anyone reading it. Added `orphan` flag to the warn log so ops can identify these silent failures.

**P1 — doc consistency**
- `CLAUDE.reply-rendering.md` still described v1.10.4 `message.part.delta` accumulation that was removed in v1.10.5 PR #74. Added version banner and notes that delta path is gone.
- v1.10.7 baseline mechanism had no documentation outside commit messages. Added a paragraph to `src/handler/CLAUDE.md` chat.ts section explaining the rationale and log signature.

**P2 — baseline observability** (`src/handler/chat.ts`)
Added `[feishu] baseline captured` log at the baseline capture point so the v1.10.7 fix is verifiable from production logs. The log includes `hasBaseline` and `textLen` — if a future 'no response' bug appears, ops can immediately see whether the baseline was captured non-empty (= reused session scenario).

## Changes

| File | Change |
|------|--------|
| `src/handler/event.ts` | +2 lines, orphan check + log field |
| `src/handler/chat.ts` | +5 lines, baseline captured log |
| `src/handler/CLAUDE.md` | +2 lines, baseline doc paragraph |
| `CLAUDE.reply-rendering.md` | +5 lines, version banner |
| `package.json` | 1.10.7 → 1.10.8 |

## Test plan

- [x] `npm run typecheck` passes
- [ ] Deploy to FAT, send a message in p2p chat
- [ ] Verify `[feishu] baseline captured` appears in logs with `hasBaseline=true` (since session is reused)
- [ ] Restart pay-dev-agent container, observe `session.error` for superpowers in logs with `orphan=true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.10.8

* **Bug Fixes**
  * Improved session error handling to distinguish orphaned error events
  * Enhanced baseline mechanism logging for recovery scenarios

* **Documentation**
  * Updated message rendering pipeline documentation
  * Documented session baseline capture and recovery behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->