### PR TITLE
fix: ack Feishu messages before async processing

### DIFF
--- a/src/feishu/gateway.ts
+++ b/src/feishu/gateway.ts
@@ -296,7 +296,24 @@ export function startFeishuGateway(options: FeishuGatewayOptions): FeishuGateway
           textPreview: text.slice(0, 80),
         })
 
-        await onMessage(ctx)
+        // 飞书 WebSocket 回调需要尽快返回 ACK；AI 处理可能耗时，放到后台避免触发重投。
+        void (async () => {
+          await onMessage(ctx)
+        })().catch((err) => {
+          log("error", "消息处理错误", {
+            error: err instanceof Error ? err.message : String(err),
+          })
+          if (fallbackShouldReply && fallbackChatId) {
+            larkClient.im.message.create({
+              data: {
+                receive_id: fallbackChatId,
+                msg_type: "text",
+                content: JSON.stringify({ text: "⚠️ 消息处理异常，请重试" }),
+              },
+              params: { receive_id_type: "chat_id" },
+            }).catch(() => {})
+          }
+        })
       } catch (err) {
         log("error", "消息处理错误", {
           error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## Summary
- Decouple `im.message.receive_v1` ACK from the long-running OpenCode message processing path.
- Run `onMessage(ctx)` in the background and keep the existing fallback error reply behavior in the async catch handler.

## Why
Feishu WebSocket callbacks should return quickly. Waiting for the full AI response before the handler resolves can make Feishu retry the same message event, which can produce duplicate replies for one user message.

## Verification
- `npm run build`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Messages are now processed asynchronously in the background, enabling faster system acknowledgment of incoming messages.

* **Bug Fixes**
  * Improved error handling for message processing failures with fallback notifications when configured.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NeverMore93/opencode-feishu/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->