### PR TITLE
fix: wait for session idle before completing Feishu replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ opencode
 |------|------|:----:|--------|------|
 | `appId` | string | 是 | — | 飞书应用 App ID |
 | `appSecret` | string | 是 | — | 飞书应用 App Secret |
-| `timeout` | number | 否 | `未设置` | 对话轮询总超时（毫秒）；未配置时不设固定超时，持续等待直到响应稳定、检测到 SSE 错误或请求被中断 |
+| `timeout` | number | 否 | `未设置` | 对话轮询总超时（毫秒）；未配置时不设固定超时，持续等待直到 OpenCode session.idle、检测到 SSE 错误或请求被中断 |
 | `logLevel` | string | 否 | `"info"` | 日志级别：fatal/error/warn/info/debug/trace |
 | `maxHistoryMessages` | number | 否 | `200` | 入群时最多摄入的历史消息条数（飞书接口按 50/页分页拉取） |
 | `pollInterval` | number | 否 | `1000` | 轮询 AI 响应的间隔（毫秒） |
-| `stablePolls` | number | 否 | `3` | 连续几次轮询内容不变视为回复完成 |
+| `stablePolls` | number | 否 | `3` | 兼容旧配置；当前回复完成以 OpenCode session.idle 为准，不再仅凭文本稳定判定完成 |
 | `dedupTtl` | number | 否 | `600000` | 消息去重缓存过期时间（毫秒） |
 | `maxResourceSize` | number | 否 | `524288000` | 单个资源最大下载大小（字节，默认 500MB） |
 | `directory` | string | 否 | `OpenCode 当前工作目录` | 默认工作目录，支持 `~` 和 `${ENV_VAR}` 展开；若 OpenCode 未提供则为空字符串 |

--- a/src/handler/action-bus.ts
+++ b/src/handler/action-bus.ts
@@ -48,6 +48,15 @@ type ActionCallback = (action: ProcessedAction) => void | Promise<void>
 /** sessionId → 订阅回调集合。 */
 const subscribers = new Map<string, Set<ActionCallback>>()
 
+/** sessionId → 最近一次 session-idle 的单调版本号。 */
+const sessionIdleVersions = new Map<string, number>()
+let sessionIdleVersion = 0
+
+/** 读取指定 session 最近一次 session-idle 的版本号。 */
+export function getSessionIdleVersion(sessionId: string): number {
+  return sessionIdleVersions.get(sessionId) ?? 0
+}
+
 /**
  * 注册某个 session 的事件订阅。
  *
@@ -88,6 +97,10 @@ export function subscribe(
  * 单个订阅者抛错不会阻塞其他订阅者，也不会把主流程打断。
  */
 export function emit(sessionId: string, action: ProcessedAction, log?: LogFn): void {
+  if (action.type === "session-idle") {
+    sessionIdleVersions.set(sessionId, ++sessionIdleVersion)
+  }
+
   const subs = subscribers.get(sessionId)
   if (!subs) return
 
@@ -104,4 +117,3 @@ export function emit(sessionId: string, action: ProcessedAction, log?: LogFn): v
       })
   }
 }
-

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -27,7 +27,7 @@ import { extractParts, type PromptPart } from "../feishu/content-extractor.js"
 import { resolveUserName } from "../feishu/user-name.js"
 import { fetchQuotedMessage } from "../feishu/quote.js"
 import type * as Lark from "@larksuiteoapi/node-sdk"
-import { subscribe } from "./action-bus.js"
+import { getSessionIdleVersion, subscribe } from "./action-bus.js"
 import type { CardKitClient } from "../feishu/cardkit.js"
 import { StreamingCard } from "../feishu/streaming-card.js"
 import { handlePermissionRequested, handleQuestionRequested, type InteractiveDeps } from "./interactive.js"
@@ -576,6 +576,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       query?: { directory: string }
       signal?: AbortSignal
       baseline?: AssistantSnapshot
+      idleAfterVersion?: number
     },
   ) => pollForResponse(currentClient, currentSessionId, {
     ...pollOptions,
@@ -604,6 +605,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       reasoningLen: baseline.reasoning.length,
     })
 
+    const idleAfterVersion = getSessionIdleVersion(session.id)
     await client.session.promptAsync({
       path: { id: session.id },
       query,
@@ -622,6 +624,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
       query,
       signal: mergeAbortSignals([signal, getRunAbortSignal(run.runId)]),
       baseline,
+      idleAfterVersion,
     })
 
     log("info", "模型响应完成", {
@@ -706,6 +709,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
             clearSessionError(session.id)
 
             try {
+              const idleAfterVersion = getSessionIdleVersion(session.id)
               await client.session.promptAsync({
                 path: { id: session.id },
                 query,
@@ -715,6 +719,7 @@ export async function handleChat(ctx: FeishuMessageContext, deps: ChatDeps, sign
               const finalText = await poll(client, session.id, {
                 timeout, pollInterval, stablePolls, query,
                 signal: mergeAbortSignals([signal, getRunAbortSignal(run.runId)]),
+                idleAfterVersion,
               })
 
               const actualModel = await fetchActualModel(client, session.id, log, query)
@@ -956,22 +961,22 @@ export async function pollForResponse(
     signal?: AbortSignal
     /** promptAsync 前捕获的 baseline，用于忽略旧 turn 的快照。 */
     baseline?: AssistantSnapshot
+    /** promptAsync 前的 session-idle 版本，用于捕获 promptAsync 期间到达的 idle。 */
+    idleAfterVersion?: number
     onSnapshot?: (snapshot: AssistantSnapshot) => void | Promise<void>
     onTick?: () => void | Promise<void>
     onTimedOut?: () => void
   },
 ): Promise<string> {
-  const { timeout, pollInterval, stablePolls, query, signal, baseline, onSnapshot, onTick, onTimedOut } = opts
+  const { timeout, pollInterval, query, signal, baseline, idleAfterVersion, onSnapshot, onTick, onTimedOut } = opts
   // 轮询开始时间，用于超时判断。
   const start = Date.now()
   // 最近一次看到的 assistant 快照。
   let lastSnapshot: AssistantSnapshot = { text: "", reasoning: "" }
-  // 连续多少次轮询结果完全相同。
-  let sameCount = 0
   let didTimeOut = false
 
   // 通过 action-bus 感知 `session.idle`，让轮询可以提前结束。
-  let sessionIdle = false
+  let sessionIdle = idleAfterVersion !== undefined && getSessionIdleVersion(sessionId) > idleAfterVersion
   const unsub = subscribe(sessionId, (action) => {
     if (action.type === "session-idle") {
       sessionIdle = true
@@ -1002,16 +1007,14 @@ export async function pollForResponse(
         throw new SessionErrorDetected(sseError)
       }
 
-      // session.idle 提前退出：收到信号后跳出循环，再做最后一次 fetch。
-      if (sessionIdle) {
-        break
-      }
+      const shouldStopAfterFetch = sessionIdle
 
       const { data: messages } = await client.session.messages({ path: { id: sessionId }, query })
       const snapshot = extractLastAssistantSnapshot(messages ?? [])
 
       // 忽略与 baseline 相同的快照（旧 turn 的回复），避免复用 session 时提前收敛。
       if (baseline && !hasAssistantSnapshotChanged(snapshot, baseline)) {
+        if (shouldStopAfterFetch) sessionIdle = false
         // 快照与 baseline 相同，说明新 turn 尚未产生输出，继续等待。
         continue
       }
@@ -1019,15 +1022,14 @@ export async function pollForResponse(
       if (hasAssistantSnapshotChanged(snapshot, lastSnapshot)) {
         // 看到新快照：更新并重置稳定计数。
         lastSnapshot = snapshot
-        sameCount = 0
         if (onSnapshot) {
           await onSnapshot(snapshot)
         }
-      } else if (snapshot.text && snapshot.text.length > 0) {
-        // 文本稳定只说明本次 polling 没抓到新快照，不能代表 OpenCode run 已完成。
-        // 完成判定以 session.idle / timeout / abort / session.error 为准，避免工具调用期间提前收尾。
-        sameCount++
-        if (sameCount >= stablePolls) continue
+      }
+
+      // session.idle 提前退出：确认不是 baseline 旧快照后跳出循环，再做最后一次 fetch。
+      if (shouldStopAfterFetch) {
+        break
       }
     }
 

--- a/src/handler/chat.ts
+++ b/src/handler/chat.ts
@@ -945,7 +945,7 @@ async function buildPromptParts(
  * 轮询等待 AI 响应稳定，返回最终文本。
  * 每次 poll 周期检查 SSE 缓存的 session error，检测到时立即终止并抛出异常。
  */
-async function pollForResponse(
+export async function pollForResponse(
   client: OpencodeClient,
   sessionId: string,
   opts: {
@@ -1024,9 +1024,10 @@ async function pollForResponse(
           await onSnapshot(snapshot)
         }
       } else if (snapshot.text && snapshot.text.length > 0) {
-        // 文本没变：累计稳定次数，达到阈值后可认为输出基本结束。
+        // 文本稳定只说明本次 polling 没抓到新快照，不能代表 OpenCode run 已完成。
+        // 完成判定以 session.idle / timeout / abort / session.error 为准，避免工具调用期间提前收尾。
         sameCount++
-        if (sameCount >= stablePolls) break
+        if (sameCount >= stablePolls) continue
       }
     }
 

--- a/src/handler/error-recovery.ts
+++ b/src/handler/error-recovery.ts
@@ -7,6 +7,7 @@
 import type { OpencodeClient } from "@opencode-ai/sdk"
 import type { LogFn } from "../types.js"
 import type { PromptPart } from "../feishu/content-extractor.js"
+import { getSessionIdleVersion } from "./action-bus.js"
 import {
   getRetryAttempts, setRetryAttempts, MAX_RETRY_ATTEMPTS, clearRetryAttempts,
   getSessionError, clearSessionError,
@@ -82,6 +83,7 @@ type PollFn = (
     stablePolls: number
     query?: { directory: string }
     signal?: AbortSignal
+    idleAfterVersion?: number
   },
 ) => Promise<string>
 
@@ -158,6 +160,7 @@ export async function tryModelRecovery(params: {
 
     // 清掉上一次调用残留的 SSE 错误，避免新一轮轮询读到旧状态。
     clearSessionError(sessionId)
+    const idleAfterVersion = getSessionIdleVersion(sessionId)
     await client.session.promptAsync({
       path: { id: sessionId },
       query,
@@ -165,7 +168,7 @@ export async function tryModelRecovery(params: {
     })
 
     const finalText = await poll(client, sessionId, {
-      timeout, pollInterval, stablePolls, query, signal,
+      timeout, pollInterval, stablePolls, query, signal, idleAfterVersion,
     })
 
     log("info", "模型恢复后响应完成", {

--- a/src/handler/event.ts
+++ b/src/handler/event.ts
@@ -357,18 +357,20 @@ function handleV2Event(event: Event, deps: EventDeps): void {
       request,
     }, deps.log)
     deps.log("info", "question.asked 事件已分发", { sessionId: evtSessionId })
-  } else if (evtType === "session.idle" && evtSessionId && pending?.hasActivity) {
+  } else if (evtType === "session.idle" && evtSessionId && pending) {
     emit(evtSessionId, {
       type: "session-idle",
       sessionId: evtSessionId,
     }, deps.log)
-    // 按需催促：检查最后一条 AI 消息是否以工具调用结尾（AI 可能卡住了）。
-    nudgeIfToolIdle(evtSessionId, deps).catch((err) => {
-      deps.log("error", "session.idle 催促任务异常退出", {
-        sessionId: evtSessionId,
-        error: err instanceof Error ? err.message : String(err),
+    if (pending.hasActivity) {
+      // 按需催促：检查最后一条 AI 消息是否以工具调用结尾（AI 可能卡住了）。
+      nudgeIfToolIdle(evtSessionId, deps).catch((err) => {
+        deps.log("error", "session.idle 催促任务异常退出", {
+          sessionId: evtSessionId,
+          error: err instanceof Error ? err.message : String(err),
+        })
       })
-    })
+    }
   }
 }
 

--- a/tests/handler/chat-polling.test.ts
+++ b/tests/handler/chat-polling.test.ts
@@ -6,7 +6,7 @@
 import { describe, it } from "node:test"
 import assert from "node:assert/strict"
 import { pollForResponse } from "../../src/handler/chat.js"
-import { emit } from "../../src/handler/action-bus.js"
+import { emit, getSessionIdleVersion } from "../../src/handler/action-bus.js"
 
 describe("pollForResponse", () => {
   it("waits for session-idle instead of completing on stable partial text", async () => {
@@ -41,5 +41,67 @@ describe("pollForResponse", () => {
       "pollForResponse must wait for session-idle instead of treating stable partial text as completion",
     )
     assert.ok(calls >= 5, "polling should continue until the session-idle event arrives")
+  })
+
+  it("observes session-idle emitted before polling subscribes", async () => {
+    let timedOut = false
+    const idleAfterVersion = getSessionIdleVersion("early-idle-session")
+    emit("early-idle-session", { type: "session-idle", sessionId: "early-idle-session" })
+
+    const client = {
+      session: {
+        async messages() {
+          return {
+            data: [{
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: "final answer" }],
+            }],
+          }
+        },
+      },
+    }
+
+    const result = await pollForResponse(client as any, "early-idle-session", {
+      timeout: 20,
+      pollInterval: 0,
+      stablePolls: 2,
+      idleAfterVersion,
+      onTimedOut: () => {
+        timedOut = true
+      },
+    })
+
+    assert.equal(result, "final answer")
+    assert.equal(timedOut, false, "early session-idle should not be lost until timeout")
+  })
+
+  it("ignores session-idle while the snapshot still matches the baseline", async () => {
+    let calls = 0
+    const baseline = { text: "previous answer", reasoning: "" }
+    const client = {
+      session: {
+        async messages() {
+          calls++
+          return {
+            data: [{
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: calls >= 2 ? "new final answer" : "previous answer" }],
+            }],
+          }
+        },
+      },
+    }
+
+    const result = await pollForResponse(client as any, "stale-idle-session", {
+      pollInterval: 0,
+      stablePolls: 2,
+      baseline,
+      onTick: () => {
+        emit("stale-idle-session", { type: "session-idle", sessionId: "stale-idle-session" })
+      },
+    })
+
+    assert.equal(result, "new final answer")
+    assert.ok(calls >= 2, "baseline-matching idle must not finalize the previous turn")
   })
 })

--- a/tests/handler/chat-polling.test.ts
+++ b/tests/handler/chat-polling.test.ts
@@ -1,0 +1,45 @@
+/**
+ * chat.ts polling regression tests.
+ *
+ * Run: npx tsx --test tests/handler/chat-polling.test.ts
+ */
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+import { pollForResponse } from "../../src/handler/chat.js"
+import { emit } from "../../src/handler/action-bus.js"
+
+describe("pollForResponse", () => {
+  it("waits for session-idle instead of completing on stable partial text", async () => {
+    let calls = 0
+    const client = {
+      session: {
+        async messages() {
+          calls++
+          if (calls === 5) {
+            emit("session-1", { type: "session-idle", sessionId: "session-1" })
+          }
+
+          const text = calls >= 5 ? "final answer" : "partial answer"
+          return {
+            data: [{
+              info: { role: "assistant" },
+              parts: [{ type: "text", text }],
+            }],
+          }
+        },
+      },
+    }
+
+    const result = await pollForResponse(client as any, "session-1", {
+      pollInterval: 0,
+      stablePolls: 2,
+    })
+
+    assert.equal(
+      result,
+      "final answer",
+      "pollForResponse must wait for session-idle instead of treating stable partial text as completion",
+    )
+    assert.ok(calls >= 5, "polling should continue until the session-idle event arrives")
+  })
+})


### PR DESCRIPTION
## Summary
- stop treating stable assistant text as reply completion while an OpenCode run may still be active
- always forward pending session.idle events to the reply poller, while keeping tool-idle nudges gated by observed activity
- add a regression test covering stable partial text followed by a later final answer
- update README completion semantics for timeout/stablePolls

## Verification
- npx tsx --test tests/handler/chat-polling.test.ts
- npm run typecheck
- npm run build

## Note
- Running the pre-existing broader handler test suite still shows an unrelated existing failure in tests/handler/errors.test.ts: poison-002-tool-choice expected SessionPoisoned but got ModelUnavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined polling behavior to correctly await session-idle events rather than treating stable text as completion, improving dialog handling reliability.

* **Documentation**
  * Updated configuration documentation to clarify that dialog polling completion is determined by session-idle events instead of text stability.

* **Tests**
  * Added regression test validating polling behavior with session-idle event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->